### PR TITLE
POST encoding to 'application/x-www-form-urlencoded' per OAuth 2.0 spec

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
   epochTimeIsPast,
 } from './authentication'
 import useLocalStorage from './Hooks'
-import { IAuthContext, IAuthProvider, TInternalConfig, FormEncoding, TTokenData, TTokenResponse } from './Types'
+import { IAuthContext, IAuthProvider, TInternalConfig, TTokenData, TTokenResponse } from './Types'
 import { validateAuthConfig } from './validateAuthConfig'
 
 const FALLBACK_EXPIRE_TIME = 600 // 10minutes
@@ -39,19 +39,12 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   let interval: any
 
   // Set default values and override from passed config
-  const {
-    decodeToken = true,
-    tokenPostEncoding = 'multi-part',
-    scope = '',
-    preLogin = () => null,
-    postLogin = () => null,
-  } = authConfig
+  const { decodeToken = true, scope = '', preLogin = () => null, postLogin = () => null } = authConfig
 
   const config: TInternalConfig = {
     ...authConfig,
     decodeToken: decodeToken,
     scope: scope,
-    tokenPostEncoding: tokenPostEncoding,
     preLogin: preLogin,
     postLogin: postLogin,
   }

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
   epochTimeIsPast,
 } from './authentication'
 import useLocalStorage from './Hooks'
-import { IAuthContext, IAuthProvider, TInternalConfig, TTokenData, TTokenResponse } from './Types'
+import { IAuthContext, IAuthProvider, TInternalConfig, FormEncoding, TTokenData, TTokenResponse } from './Types'
 import { validateAuthConfig } from './validateAuthConfig'
 
 const FALLBACK_EXPIRE_TIME = 600 // 10minutes
@@ -39,14 +39,21 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   let interval: any
 
   // Set default values and override from passed config
-  const { decodeToken = true, scope = '', preLogin = () => null, postLogin = () => null } = authConfig
+  const {
+    decodeToken = true,
+    tokenPostEncoding = 'multi-part',
+    scope = '',
+    preLogin = () => null,
+    postLogin = () => null,
+  } = authConfig
 
   const config: TInternalConfig = {
+    ...authConfig,
     decodeToken: decodeToken,
     scope: scope,
+    tokenPostEncoding: tokenPostEncoding,
     preLogin: preLogin,
     postLogin: postLogin,
-    ...authConfig,
   }
 
   validateAuthConfig(config)

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -1,5 +1,20 @@
 import { ReactNode } from 'react'
 
+interface TTokenRqBase {
+  grant_type: string
+  scope: string
+  client_id: string
+  redirect_uri: string
+}
+interface TTokenRequestWithCodeAndVerifier extends TTokenRqBase {
+  code: string
+  code_verifier: string
+}
+interface TTokenRequestForRefresh extends TTokenRqBase {
+  refresh_token: string
+}
+export type TTokenRequest = TTokenRequestWithCodeAndVerifier | TTokenRequestForRefresh
+
 export type TTokenData = {
   [x: string]: any
 }
@@ -32,6 +47,7 @@ export type TAuthConfig = {
   clientId: string
   authorizationEndpoint: string
   tokenEndpoint: string
+  tokenPostEncoding: FormEncoding
   redirectUri: string
   scope?: string
   logoutEndpoint?: string
@@ -51,9 +67,12 @@ export type TInternalConfig = {
   clientId: string
   authorizationEndpoint: string
   tokenEndpoint: string
+  tokenPostEncoding: FormEncoding
   redirectUri: string
   scope: string
   preLogin?: () => void
   postLogin?: () => void
   decodeToken: boolean
 }
+
+export type FormEncoding = 'multi-part' | 'url-encoded'

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -47,7 +47,6 @@ export type TAuthConfig = {
   clientId: string
   authorizationEndpoint: string
   tokenEndpoint: string
-  tokenPostEncoding: FormEncoding
   redirectUri: string
   scope?: string
   logoutEndpoint?: string
@@ -67,12 +66,9 @@ export type TInternalConfig = {
   clientId: string
   authorizationEndpoint: string
   tokenEndpoint: string
-  tokenPostEncoding: FormEncoding
   redirectUri: string
   scope: string
   preLogin?: () => void
   postLogin?: () => void
   decodeToken: boolean
 }
-
-export type FormEncoding = 'multi-part' | 'url-encoded'

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -6,11 +6,11 @@ interface TTokenRqBase {
   client_id: string
   redirect_uri: string
 }
-interface TTokenRequestWithCodeAndVerifier extends TTokenRqBase {
+export interface TTokenRequestWithCodeAndVerifier extends TTokenRqBase {
   code: string
   code_verifier: string
 }
-interface TTokenRequestForRefresh extends TTokenRqBase {
+export interface TTokenRequestForRefresh extends TTokenRqBase {
   refresh_token: string
 }
 export type TTokenRequest = TTokenRequestWithCodeAndVerifier | TTokenRequestForRefresh

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,12 +1,5 @@
 import { generateCodeChallenge, generateRandomString } from './pkceUtils'
-import {
-  TInternalConfig,
-  TTokenData,
-  TAzureADErrorResponse,
-  TTokenResponse,
-  FormEncoding,
-  TTokenRequest,
-} from './Types'
+import { TInternalConfig, TTokenData, TAzureADErrorResponse, TTokenResponse, TTokenRequest } from './Types'
 
 const codeVerifierStorageKey = 'PKCE_code_verifier'
 // [ AzureAD,]
@@ -47,23 +40,14 @@ function buildUrlEncodedRequest(tokenRequest: TTokenRequest): string {
   return s
 }
 
-function buildMultiPartRequest(tokenRequest: TTokenRequest): FormData {
-  const formData = new FormData()
-  for (const pair of Object.entries(tokenRequest)) {
-    formData.set(pair[0], pair[1])
-  }
-  return formData
-}
-
 function postWithFormData(
   tokenEndpoint: string,
-  tokenRequest: TTokenRequest,
-  encoding: FormEncoding
+  tokenRequest: TTokenRequest
 ): Promise<TTokenResponse> {
   return fetch(tokenEndpoint, {
     method: 'POST',
-    body: encoding === 'url-encoded' ? buildUrlEncodedRequest(tokenRequest) : buildMultiPartRequest(tokenRequest),
-    headers: encoding === 'url-encoded' ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {},
+    body: buildUrlEncodedRequest(tokenRequest),
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   }).then((response: Response) => {
     if (!response.ok) {
       console.error(response)
@@ -105,7 +89,7 @@ export const fetchTokens = (config: TInternalConfig): Promise<TTokenResponse> =>
     redirect_uri: config.redirectUri,
     code_verifier: codeVerifier,
   }
-  return postWithFormData(config.tokenEndpoint, tokenRequest, config.tokenPostEncoding)
+  return postWithFormData(config.tokenEndpoint, tokenRequest)
 }
 
 export const fetchWithRefreshToken = (props: {
@@ -120,7 +104,7 @@ export const fetchWithRefreshToken = (props: {
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
   }
-  return postWithFormData(config.tokenEndpoint, tokenRequest, config.tokenPostEncoding)
+  return postWithFormData(config.tokenEndpoint, tokenRequest)
 }
 
 /**

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,5 +1,12 @@
 import { generateCodeChallenge, generateRandomString } from './pkceUtils'
-import { TInternalConfig, TTokenData, TAzureADErrorResponse, TTokenResponse } from './Types'
+import {
+  TInternalConfig,
+  TTokenData,
+  TAzureADErrorResponse,
+  TTokenResponse,
+  FormEncoding,
+  TTokenRequest,
+} from './Types'
 
 const codeVerifierStorageKey = 'PKCE_code_verifier'
 // [ AzureAD,]
@@ -7,7 +14,7 @@ export const EXPIRED_REFRESH_TOKEN_ERROR_CODES = ['AADSTS700084']
 
 export async function logIn(config: TInternalConfig) {
   // Create and store a random string in localStorage, used as the 'code_verifier'
-  const codeVerifier = generateRandomString(40)
+  const codeVerifier = generateRandomString(96)
   localStorage.setItem(codeVerifierStorageKey, codeVerifier)
 
   // Hash and Base64URL encode the code_verifier, used as the 'code_challenge'
@@ -32,10 +39,31 @@ function isTokenResponse(body: TAzureADErrorResponse | TTokenResponse): body is 
   return (body as TTokenResponse).access_token !== undefined
 }
 
-function postWithFormData(tokenEndpoint: string, formData: FormData): Promise<TTokenResponse> {
+function buildUrlEncodedRequest(tokenRequest: TTokenRequest): string {
+  let s = ''
+  for (const pair of Object.entries(tokenRequest)) {
+    s += (s ? '&' : '') + pair[0] + '=' + encodeURIComponent(pair[1])
+  }
+  return s
+}
+
+function buildMultiPartRequest(tokenRequest: TTokenRequest): FormData {
+  const formData = new FormData()
+  for (const pair of Object.entries(tokenRequest)) {
+    formData.set(pair[0], pair[1])
+  }
+  return formData
+}
+
+function postWithFormData(
+  tokenEndpoint: string,
+  tokenRequest: TTokenRequest,
+  encoding: FormEncoding
+): Promise<TTokenResponse> {
   return fetch(tokenEndpoint, {
     method: 'POST',
-    body: formData,
+    body: encoding === 'url-encoded' ? buildUrlEncodedRequest(tokenRequest) : buildMultiPartRequest(tokenRequest),
+    headers: encoding === 'url-encoded' ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {},
   }).then((response: Response) => {
     if (!response.ok) {
       console.error(response)
@@ -69,15 +97,15 @@ export const fetchTokens = (config: TInternalConfig): Promise<TTokenResponse> =>
     throw Error("Can't get tokens without the CodeVerifier. \nHas authentication taken place?")
   }
 
-  const formData = new FormData()
-  formData.append('grant_type', 'authorization_code')
-  formData.append('code', authCode)
-  formData.append('scope', config.scope)
-  formData.append('client_id', config.clientId)
-  formData.append('redirect_uri', config.redirectUri)
-  formData.append('code_verifier', codeVerifier)
-
-  return postWithFormData(config.tokenEndpoint, formData)
+  const tokenRequest: TTokenRequest = {
+    grant_type: 'authorization_code',
+    code: authCode,
+    scope: config.scope,
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    code_verifier: codeVerifier,
+  }
+  return postWithFormData(config.tokenEndpoint, tokenRequest, config.tokenPostEncoding)
 }
 
 export const fetchWithRefreshToken = (props: {
@@ -85,14 +113,14 @@ export const fetchWithRefreshToken = (props: {
   refreshToken: string
 }): Promise<TTokenResponse> => {
   const { config, refreshToken } = props
-  const formData = new FormData()
-  formData.append('grant_type', 'refresh_token')
-  formData.append('refresh_token', refreshToken)
-  formData.append('scope', config.scope)
-  formData.append('client_id', config.clientId)
-  formData.append('redirect_uri', config.redirectUri)
-
-  return postWithFormData(config.tokenEndpoint, formData)
+  const tokenRequest: TTokenRequest = {
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    scope: config.scope,
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+  }
+  return postWithFormData(config.tokenEndpoint, tokenRequest, config.tokenPostEncoding)
 }
 
 /**

--- a/src/package.json
+++ b/src/package.json
@@ -29,7 +29,8 @@
     "azure",
     "github",
     "keycloak",
-    "microsoft"
+    "microsoft",
+    "fusionauth"
   ],
   "author": "Stig Oskar Ofstad",
   "license": "MIT",


### PR DESCRIPTION
The purpose of these changes is compatibility with FusionAuth.

These changes add a configuration key of 'tokenPostEncoding' as a pseudo
enumeration that is either 'multi-part' ( the default ) or 'url-encoded'.
Setting this configuration key to a value of 'url-encoded' will cause
the token requests to be sent as 'application/x-www-form-urlencoded'
POSTs. ( FusionAuth does not support multi-part POSTS for tokens )

This is accomplished by explicitly typing the token request data and
passing that into the function performing the fetch. The actual POST
body is then built along with the proper headers in the function
doing the fetching.

This commit also increases the code verifier random length to 96.
( FusionAuth seems to reject shorter code verifiers )

**EDIT** It looks like the request for a token and refresh token _MUST_ be in 'application/x-www-form-urlencoded' format according to the OAuth 2.0 spec. https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3. I will update this pull request to remove the configuration option and always use the url-encoded style.

closes issue #14 