### PR TITLE
feat: support extra parameters in the auth request

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ import { AuthContext, AuthProvider, TAuthConfig } from "react-oauth2-code-pkce"
 
 const authConfig: TAuthConfig = {
   clientId: 'myClientID',
-  authorizationEndpoint: 'myAuthEndpoint',
-  tokenEndpoint: 'myTokenEndpoint',
+  authorizationEndpoint: 'https://myAuthProvider.com/auth',
+  tokenEndpoint: 'https://myAuthProvider.com/token',
   redirectUri: 'http://localhost:3000/',
   scope: 'someScope openid',
 }
@@ -133,7 +133,11 @@ type TAuthConfig = {
   // By default, it will automatically redirect the user to the login server if not already logged in.
   // If set to false, you need to call the "login()" function to login (e.g. with a "Login" button)
   autoLogin?: boolean  // default: true
-  // Can be used to provide any non-standard parameters to the authorization request
+  // Can be used to provide any non-standard parameters to the authentication request
+  extraAuthParameters?: { [key: string]: string | boolean | number }  // default: null
+  // Can be used to provide any non-standard parameters to the token request
+  extraTokenParameters?: { [key: string]: string | boolean | number } // default: null
+  // Superseded by 'extraTokenParameters' options. Will be deprecated in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }  // default: null
 }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -57,7 +57,10 @@ export type TAuthConfig = {
   postLogin?: () => void
   decodeToken?: boolean
   autoLogin?: boolean
+  // TODO: Remove in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }
+  extraAuthParameters?: { [key: string]: string | boolean | number }
+  extraTokenParameters?: { [key: string]: string | boolean | number }
 }
 
 export type TAzureADErrorResponse = {
@@ -76,5 +79,8 @@ export type TInternalConfig = {
   postLogin?: () => void
   decodeToken: boolean
   autoLogin: boolean
+  // TODO: Remove in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }
+  extraAuthParameters?: { [key: string]: string | boolean | number }
+  extraTokenParameters?: { [key: string]: string | boolean | number }
 }

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -28,6 +28,7 @@ export async function redirectToLogin(config: TInternalConfig) {
       redirect_uri: config.redirectUri,
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
+      ...config.extraAuthParameters,
     })
     // Call any preLogin function in authConfig
     if (config?.preLogin) config.preLogin()
@@ -93,7 +94,9 @@ export const fetchTokens = (config: TInternalConfig): Promise<TTokenResponse> =>
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
     code_verifier: codeVerifier,
+    // TODO: Remove in 2.0
     ...config.extraAuthParams,
+    ...config.extraTokenParameters,
   }
   return postWithXForm(config.tokenEndpoint, tokenRequest)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ const authConfig = {
   postLogin: () => window.location.replace(localStorage.getItem('preLoginPath') || ''),
   decodeToken: true,
   scope: 'User.read',
-  // autoLogin: false,
 }
 
 function LoginInfo() {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Plug-and-play react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/validateAuthConfig.ts
+++ b/src/validateAuthConfig.ts
@@ -18,4 +18,14 @@ export function validateAuthConfig(config: TInternalConfig) {
     )
   if (stringIsUnset(config?.redirectUri))
     throw Error("'redirectUri' must be set in the 'AuthConfig' object passed to 'react-oauth2-code-pkce' AuthProvider")
+  if (config?.extraAuthParams)
+    console.warn(
+      "The 'extraAuthParams' configuration parameter will be deprecated. You should use " +
+        "'extraTokenParameters' instead."
+    )
+  if (config?.extraAuthParams && config?.extraTokenParameters)
+    console.warn(
+      "Using both 'extraAuthParams' and 'extraTokenParameters' is not recommended. " +
+        "They do the same thing, and you should only use 'extraTokenParameters'"
+    )
 }

--- a/tests/token_request.test.tsx
+++ b/tests/token_request.test.tsx
@@ -50,6 +50,11 @@ const authConfig: TAuthConfig = {
     prompt: true,
     client_id: 'anotherClientId',
   },
+  extraTokenParameters: {
+    prompt: true,
+    client_id: 'anotherClientId',
+    testKey: 'test Value',
+  },
 }
 
 const AuthConsumer = () => {
@@ -57,7 +62,7 @@ const AuthConsumer = () => {
   return <div>{tokenData?.name}</div>
 }
 
-describe('make auth request with extra parameters', () => {
+describe('make token request with extra parameters', () => {
   const wrapper = ({ children }: any) => <AuthProvider authConfig={authConfig}>{children}</AuthProvider>
 
   // Setting up a state similar to what it would be just after redirect back from auth provider
@@ -72,13 +77,13 @@ describe('make auth request with extra parameters', () => {
     writable: true,
     value: location,
   })
-  it('calls the auth endpoint with these parameters', async () => {
+  it('calls the token endpoint with these parameters', async () => {
     await act(async () => {
       render(<AuthConsumer />, { wrapper })
     })
 
     expect(fetch).toHaveBeenCalledWith('myTokenEndpoint', {
-      body: 'grant_type=authorization_code&code=1234&scope=someScope%20openid&client_id=anotherClientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&code_verifier=arandomstring&prompt=true',
+      body: 'grant_type=authorization_code&code=1234&scope=someScope%20openid&client_id=anotherClientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&code_verifier=arandomstring&prompt=true&testKey=test%20Value',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },


### PR DESCRIPTION
Some auth providers accept or require non-standard parameters for the authentication request.

This commit adds an additional optional configuration parameter for providing arbitrary extra parameters to that request.

closes #25 