### PR TITLE
fix: logout function did not redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,13 @@ import { AuthContext, AuthProvider } from "react-oauth2-code-pkce"
 
 ```typescript
 type TAuthConfig = {
-  // For required parameters, refer to the auth providers documentation
+  // Id of your app at the authentication provider
   clientId: string  // Required
+  // URL for the authentication endpoint at the authentication provider
   authorizationEndpoint: string  // Required
+  // URL for the token endpoint at the authentication provider
   tokenEndpoint: string  // Required
+  // Which URL the auth provider should redirect the user after loging out
   redirectUri: string  // Required
   scope?: string  // default: ''
   // Which URL to call for logging out of the auth provider

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,16 +1,16 @@
 import React, { createContext, useEffect, useState } from 'react' // eslint-disable-line
 import {
-  decodeJWT,
-  epochAtSecondsFromNow,
-  epochTimeIsPast,
   errorMessageForExpiredRefreshToken,
   fetchTokens,
   fetchWithRefreshToken,
+  redirectToLogout,
   redirectToLogin,
 } from './authentication'
 import useLocalStorage from './Hooks'
 import { IAuthContext, IAuthProvider, TInternalConfig, TTokenData, TTokenResponse } from './Types'
 import { validateAuthConfig } from './validateAuthConfig'
+import { epochAtSecondsFromNow, epochTimeIsPast } from './timeUtils'
+import { decodeJWT } from './decodeJWT'
 
 const FALLBACK_EXPIRE_TIME = 600 // 10minutes
 
@@ -68,6 +68,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     setIdToken(undefined)
     setTokenData(undefined)
     setLoginInProgress(false)
+    if (config?.logoutEndpoint && refreshToken) redirectToLogout(config, refreshToken)
   }
 
   function login() {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -6,13 +6,16 @@ interface TTokenRqBase {
   client_id: string
   redirect_uri: string
 }
+
 export interface TTokenRequestWithCodeAndVerifier extends TTokenRqBase {
   code: string
   code_verifier: string
 }
+
 export interface TTokenRequestForRefresh extends TTokenRqBase {
   refresh_token: string
 }
+
 export type TTokenRequest = TTokenRequestWithCodeAndVerifier | TTokenRequestForRefresh
 
 export type TTokenData = {
@@ -75,6 +78,7 @@ export type TInternalConfig = {
   tokenEndpoint: string
   redirectUri: string
   scope: string
+  logoutEndpoint?: string
   preLogin?: () => void
   postLogin?: () => void
   decodeToken: boolean

--- a/src/decodeJWT.ts
+++ b/src/decodeJWT.ts
@@ -1,0 +1,26 @@
+import { TTokenData } from './Types'
+
+/**
+ * Decodes the base64 encoded JWT. Returns a TToken.
+ */
+export const decodeJWT = (token: string): TTokenData => {
+  try {
+    const base64Url = token.split('.')[1]
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map(function (c) {
+          return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+        })
+        .join('')
+    )
+    return JSON.parse(jsonPayload)
+  } catch (e) {
+    console.error(e)
+    throw Error(
+      'Failed to decode the access token.\n\tIs it a proper Java Web Token?\n\t' +
+        "You can disable JWT decoding by setting the 'decodeToken' value to 'false' the configuration."
+    )
+  }
+}

--- a/src/httpUtils.ts
+++ b/src/httpUtils.ts
@@ -1,0 +1,23 @@
+import { TTokenRequest } from './Types'
+
+function buildUrlEncodedRequest(request: TTokenRequest): string {
+  let queryString = ''
+  Object.entries(request).forEach(([key, value]) => {
+    queryString += (queryString ? '&' : '') + key + '=' + encodeURIComponent(value)
+  })
+  return queryString
+}
+
+export function postWithXForm(url: string, request: TTokenRequest): Promise<Response> {
+  return fetch(url, {
+    method: 'POST',
+    body: buildUrlEncodedRequest(request),
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  }).then((response: Response) => {
+    if (!response.ok) {
+      console.error(response)
+      throw Error(response.statusText)
+    }
+    return response
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,13 @@ const authConfig = {
   authorizationEndpoint:
     'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/authorize',
   tokenEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/token',
-  redirectUri: 'http://localhost:3000/', // Example to redirect back to original path after login has completed
+  logoutEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/logout',
+  redirectUri: 'http://localhost:3000/',
   preLogin: () => localStorage.setItem('preLoginPath', window.location.pathname),
   postLogin: () => window.location.replace(localStorage.getItem('preLoginPath') || ''),
   decodeToken: true,
   scope: 'User.read',
+  autoLogin: false,
 }
 
 function LoginInfo() {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Plug-and-play react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/timeUtils.ts
+++ b/src/timeUtils.ts
@@ -1,0 +1,12 @@
+// Returns epoch time (in seconds) for when the token will expire
+export const epochAtSecondsFromNow = (secondsFromNow: number) => Math.round(Date.now() / 1000 + secondsFromNow)
+
+/**
+ * Check if the Access Token has expired.
+ * Will return True if the token has expired, OR there is less than 5min until it expires.
+ */
+export function epochTimeIsPast(timestamp: number): boolean {
+  const now = Math.round(Date.now()) / 1000
+  const nowWithBuffer = now + 120
+  return nowWithBuffer >= timestamp
+}

--- a/tests/authentication.test.ts
+++ b/tests/authentication.test.ts
@@ -1,4 +1,5 @@
-import { decodeJWT, epochAtSecondsFromNow, epochTimeIsPast } from '../src/authentication'
+import { decodeJWT } from '../src/decodeJWT'
+import { epochAtSecondsFromNow, epochTimeIsPast } from '../src/timeUtils'
 
 test('decode a JWT token', () => {
   const tokenData = decodeJWT(


### PR DESCRIPTION
Fix a bug where the provided logout function did not redirect the browser to the authentication providers logout endpoint.

closes #23 
