### PR TITLE
feat: RefreshTokenExpired handler

### DIFF
--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 function useLocalStorage<T>(key: string, initialValue: T): [T, (v: T) => void] {
   const [storedValue, setStoredValue] = useState<T>(() => {
@@ -19,6 +19,16 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, (v: T) => void] {
       console.log(`Failed to store value '${value}' for key '${key}'`)
     }
   }
+
+  useEffect(() => {
+    const storageEventHandler = (event: StorageEvent) => {
+      if (event.storageArea === localStorage && event.key === key) {
+        setStoredValue(JSON.parse(event.newValue ?? '') as T)
+      }
+    }
+    window.addEventListener('storage', storageEventHandler, false)
+    return () => window.removeEventListener('storage', storageEventHandler, false)
+  })
 
   return [storedValue, setValue]
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -58,12 +58,17 @@ export type TAuthConfig = {
   logoutRedirect?: string
   preLogin?: () => void
   postLogin?: () => void
+  onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void
   decodeToken?: boolean
   autoLogin?: boolean
   // TODO: Remove in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }
   extraAuthParameters?: { [key: string]: string | boolean | number }
   extraTokenParameters?: { [key: string]: string | boolean | number }
+}
+
+export type TRefreshTokenExpiredEvent = {
+  login: () => void
 }
 
 export type TAzureADErrorResponse = {
@@ -81,6 +86,7 @@ export type TInternalConfig = {
   logoutEndpoint?: string
   preLogin?: () => void
   postLogin?: () => void
+  onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void
   decodeToken: boolean
   autoLogin: boolean
   // TODO: Remove in 2.0

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const authConfig = {
   redirectUri: 'http://localhost:3000/',
   preLogin: () => localStorage.setItem('preLoginPath', window.location.pathname),
   postLogin: () => window.location.replace(localStorage.getItem('preLoginPath') || ''),
+  onRefreshTokenExpire: (event) => window.confirm('Tokens have expired. Log in?') && event.login(),
   decodeToken: true,
   scope: 'User.read',
   autoLogin: false,

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ function LoginInfo() {
     return (
       <>
         <div style={{ color: 'red' }}>An error occurred during authentication: {error}</div>
-        <button onClick={() => logOut()}>Logout</button>
+        <button onClick={logOut}>Logout</button>
       </>
     )
   }
@@ -35,13 +35,13 @@ function LoginInfo() {
     return (
       <>
         <div style={{ backgroundColor: 'red' }}>You are not logged in</div>
-        <button onClick={() => login()}>Login</button>
+        <button onClick={login}>Login</button>
       </>
     )
   return (
     <>
       <div>
-        <button onClick={() => logOut()}>Logout</button>
+        <button onClick={logOut}>Logout</button>
         <h4>Access Token (JWT)</h4>
         <pre
           style={{


### PR DESCRIPTION
## Why is this pull request needed, and what does it change?
As presented in #30 the library currently does a slightly risky, undefined redirect whenever it notices that the refresh token has expired.

This PR adds an option to TAuthConfig: `onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void`. This callback allows users to react to the tokens expiring, and then lets the users handle it however they want. The `login` function is also exposed in the event to allow the users to e.g. do `onRefreshTokenExpire: (event) => window.confirm("Expired. Login again?) && event.login()`.

## Issues related to this change
Closes #30. 