### PR TITLE
fix: bad handling of failed token refresh

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Each line is a file pattern followed by one or more owners.
+# Order matter. If two rules match the same file, only the last one is used
+
+# Repo owners
+*      @soofstad

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "react-scripts": ">=5.0.1"
   },
   "scripts": {
-    "start": "ESLINT_NO_DEV_ERRORS='true' react-scripts start ./src/index.js",
+    "start": "ESLINT_NO_DEV_ERRORS='true' react-scripts start",
     "build": "react-scripts build",
     "test": "jest --silent",
     "test:watch": "jest --silent --watch"

--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,9 @@ const authConfig = {
   clientId: '6559ce69-219d-4e82-b6ed-889a861c7c94',
   authorizationEndpoint:
     'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/authorize',
-  tokenEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/token',
-  logoutEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/logout',
-  redirectUri: 'http://localhost:3000/',
-  preLogin: () => localStorage.setItem('preLoginPath', window.location.pathname),
-  postLogin: () => window.location.replace(localStorage.getItem('preLoginPath') || ''),
+  tokenEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/token', // logoutEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/logout',
+  redirectUri: 'http://localhost:3000/', // preLogin: () => localStorage.setItem('preLoginPath', window.location.pathname),
+  // postLogin: () => window.location.replace(localStorage.getItem('preLoginPath') || ''),
   onRefreshTokenExpire: (event) => window.confirm('Tokens have expired. Log in?') && event.login(),
   decodeToken: true,
   scope: 'User.read',
@@ -22,43 +20,13 @@ function LoginInfo() {
 
   if (loginInProgress) return null
 
-  if (error) {
-    return (
-      <>
-        <div style={{ color: 'red' }}>An error occurred during authentication: {error}</div>
-        <button onClick={logOut}>Logout</button>
-      </>
-    )
-  }
-
-  if (!token)
-    return (
-      <>
-        <div style={{ backgroundColor: 'red' }}>You are not logged in</div>
-        <button onClick={login}>Login</button>
-      </>
-    )
   return (
     <>
-      <div>
-        <button onClick={logOut}>Logout</button>
-        <h4>Access Token (JWT)</h4>
-        <pre
-          style={{
-            width: '400px',
-            margin: '10px',
-            padding: '5px',
-            border: 'black 2px solid',
-            wordBreak: 'break-all',
-            whiteSpace: 'break-spaces',
-          }}
-        >
-          {token}
-        </pre>
-      </div>
-      {authConfig.decodeToken && (
-        <div>
-          <h4>Login Information from Access Token and IdToken (if any)</h4>
+      {error && <div style={{ color: 'red' }}>An error occurred during authentication: {error}</div>}
+      {token ? (
+        <>
+          <button onClick={logOut}>Logout</button>
+          <h4>Access Token (JWT)</h4>
           <pre
             style={{
               width: '400px',
@@ -69,9 +37,31 @@ function LoginInfo() {
               whiteSpace: 'break-spaces',
             }}
           >
-            {JSON.stringify(tokenData, null, 2)}
+            {token}
           </pre>
-        </div>
+          {authConfig.decodeToken && (
+            <div>
+              <h4>Login Information from Access Token and IdToken (if any)</h4>
+              <pre
+                style={{
+                  width: '400px',
+                  margin: '10px',
+                  padding: '5px',
+                  border: 'black 2px solid',
+                  wordBreak: 'break-all',
+                  whiteSpace: 'break-spaces',
+                }}
+              >
+                {JSON.stringify(tokenData, null, 2)}
+              </pre>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div style={{ backgroundColor: 'red' }}>You are not logged in</div>
+          <button onClick={login}>Login</button>
+        </>
       )}
     </>
   )

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Plug-and-play react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes two bugs:
 - Wrong type for caught error in 'get token with refresh_token'-request
 - Failed token refresh on page load did not trigger a new login, causing users to have to logout, and -in again manually.

NOTE: Failed silent refresh will still fail.  There are two options to handle this;
 1. Show a message to the user that he/she should refresh their browser
 2. Provide the `onRefreshTokenExpired` config parameter, and handle the event in  your callback