### PR TITLE
fix: wrong config param used for logout redirect

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -84,6 +84,7 @@ export type TInternalConfig = {
   redirectUri: string
   scope: string
   logoutEndpoint?: string
+  logoutRedirect?: string
   preLogin?: () => void
   postLogin?: () => void
   onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -107,7 +107,7 @@ export function redirectToLogout(config: TInternalConfig, token: string) {
     token_type_hint: 'refresh_token',
     client_id: config.clientId,
     // TODO: Add extra logout params
-    post_logout_redirect_uri: config.redirectUri,
+    post_logout_redirect_uri: config.logoutRedirect ?? config.redirectUri,
   })
   window.location.replace(`${config.logoutEndpoint}?${params.toString()}`)
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Plug-and-play react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What does this pull request change?
- Use config parameter "logoutRedirect" instead of "redirectUrl" for logout

## Why is this pull request needed?
- Wrong param was used, according to documentation


## Issues related to this change
resolves #40 