### PR TITLE
fix: handle all 400 refresh requests as "expired"

### DIFF
--- a/examples/microsoft-auth-provider/web-app/package.json
+++ b/examples/microsoft-auth-provider/web-app/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "react-oauth2-code-pkce": ">=1.8.1",
+    "react-oauth2-code-pkce": ">=1.8.2",
     "react-scripts": "^5.0.1"
   },
   "scripts": {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -71,11 +71,6 @@ export type TRefreshTokenExpiredEvent = {
   login: () => void
 }
 
-export type TAzureADErrorResponse = {
-  error_description: string
-  [k: string]: unknown
-}
-
 // The AuthProviders internal config type. All values will be set by user provided, or default values
 export type TInternalConfig = {
   clientId: string

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,11 @@
+export class FetchError extends Error {
+  status: number
+  statusText: string
+
+  constructor(status: number, statusText: string, message: string) {
+    super(message)
+    this.name = 'FetchError'
+    this.status = status
+    this.statusText = statusText
+  }
+}

--- a/src/httpUtils.ts
+++ b/src/httpUtils.ts
@@ -1,4 +1,5 @@
 import { TTokenRequest } from './Types'
+import { FetchError } from './errors'
 
 function buildUrlEncodedRequest(request: TTokenRequest): string {
   let queryString = ''
@@ -8,15 +9,15 @@ function buildUrlEncodedRequest(request: TTokenRequest): string {
   return queryString
 }
 
-export function postWithXForm(url: string, request: TTokenRequest): Promise<Response> {
+export async function postWithXForm(url: string, request: TTokenRequest): Promise<Response> {
   return fetch(url, {
     method: 'POST',
     body: buildUrlEncodedRequest(request),
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-  }).then((response: Response) => {
+  }).then(async (response: Response) => {
     if (!response.ok) {
-      console.error(response)
-      throw Error(response.statusText)
+      const responseBody = await response.text()
+      throw new FetchError(response.status, response.statusText, responseBody)
     }
     return response
   })

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-oauth2-code-pkce",
   "version": "1.8.3",
-  "description": "Plug-and-play react package for OAuth2 Authorization Code flow with PKCE",
+  "description": "Provider agnostic react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {},


### PR DESCRIPTION
This commit changes how failed refresh requests are handled.

Since we often have to assume the refreshToken expire time, it will sometimes be wrong. Therefore, we might make a refresh request with an expired refreshToken.

This change make sure all 400 status codes on the refresh request are handled as if the refreshToken has expired. Even if there might be other reasons.

closes #38 