### PR TITLE
Add support to non-standard logout parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ type TAuthConfig = {
   extraAuthParameters?: { [key: string]: string | boolean | number }  // default: null
   // Can be used to provide any non-standard parameters to the token request
   extraTokenParameters?: { [key: string]: string | boolean | number } // default: null
+  // Can be used to provide any non-standard parameters to the logout request
+  extraLogoutParameters?: { [key: string]: string | boolean | number } // default: null
   // Superseded by 'extraTokenParameters' options. Will be deprecated in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }  // default: null
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -66,6 +66,7 @@ export type TAuthConfig = {
   extraAuthParams?: { [key: string]: string | boolean | number }
   extraAuthParameters?: { [key: string]: string | boolean | number }
   extraTokenParameters?: { [key: string]: string | boolean | number }
+  extraLogoutParameters?: { [key: string]: string | boolean | number }
 }
 
 export type TRefreshTokenExpiredEvent = {
@@ -90,4 +91,5 @@ export type TInternalConfig = {
   extraAuthParams?: { [key: string]: string | boolean | number }
   extraAuthParameters?: { [key: string]: string | boolean | number }
   extraTokenParameters?: { [key: string]: string | boolean | number }
+  extraLogoutParameters?: { [key: string]: string | boolean | number }
 }

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -104,6 +104,7 @@ export function redirectToLogout(config: TInternalConfig, token: string) {
     client_id: config.clientId,
     // TODO: Add extra logout params
     post_logout_redirect_uri: config.logoutRedirect ?? config.redirectUri,
+    ...config.extraLogoutParameters,
   })
   window.location.replace(`${config.logoutEndpoint}?${params.toString()}`)
 }


### PR DESCRIPTION
## What does this pull request change?
Add new config extraLogoutParameters. Use the extra logout parameters in the logout request.

## Why is this pull request needed?
To support non-standard logout parameters.

## Issues related to this change
https://github.com/soofstad/react-oauth2-pkce/issues/51