### PR TITLE
Exposing refresh token in AuthContext

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -18,6 +18,7 @@ const FALLBACK_EXPIRE_TIME = 600 // 10minutes
 
 export const AuthContext = createContext<IAuthContext>({
   token: '',
+  refreshToken: '',
   login: () => null,
   logOut: () => null,
   error: null,
@@ -208,7 +209,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   }, []) // eslint-disable-line
 
   return (
-    <AuthContext.Provider value={{ token, tokenData, idToken, idTokenData, login, logOut, error, loginInProgress }}>
+    <AuthContext.Provider value={{ token, refreshToken, tokenData, idToken, idTokenData, login, logOut, error, loginInProgress }}>
       {children}
     </AuthContext.Provider>
   )

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -39,6 +39,7 @@ export interface IAuthProvider {
 
 export interface IAuthContext {
   token: string
+  refreshToken: string
   logOut: (state?: string, logoutHint?: string) => void
   login: () => void
   error: string | null


### PR DESCRIPTION
## What does this pull request change?
I have a use case where I'd like to collect and store the refresh token for some async processes that I run but I don't have a way to get it.

## Why is this pull request needed?
Currently the refresh token isn't exposed in the context

