### PR TITLE
fix: autologin when loading page w/ expired refreshToken

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -146,7 +146,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
       }
       // The refreshToken has expired
       else {
-        return handleExpiredRefreshToken()
+        return handleExpiredRefreshToken(initial)
       }
     }
     // The token has not expired. Do nothing


### PR DESCRIPTION
Fixes a bug where the "initial" flag was not passed to "handleExpiredRefreshToken()" on first page load when the refreshToken was expired.
This caused the "onRefreshTokenExpire()" callback to be called on pageload.

