### PR TITLE
fix: broken-code-state

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -175,13 +175,15 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
         fetchTokens(config)
           .then((tokens: TTokenResponse) => {
             handleTokenResponse(tokens)
-            window.history.replaceState(null, '', window.location.pathname) // Clear ugly url params
             // Call any postLogin function in authConfig
             if (config?.postLogin) config.postLogin()
           })
           .catch((error: Error) => {
             console.error(error)
             setError(error.message)
+          })
+          .finally(() => {
+            window.history.replaceState(null, '', window.location.pathname) // Clear ugly url params
           })
       }
     } else if (!token) {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Provider agnostic react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2015",
     "module": "commonjs",
-    "lib": ["es2016", "es2017", "dom"],
+    "lib": ["ESNext", "DOM"],
     "allowJs": false,
     "jsx": "react",
     "declaration": true,


### PR DESCRIPTION
## What does this pull request change?
Moves 
```typescript
window.history.replaceState(null, '', window.location.pathname) // Clear ugly url params
```
into a `finally`-clause, to ensure it is called both for successful and failing promises. 

## Why is this pull request needed?
Users reported broken auth states that were not remedied by refreshing the page.

## Issues related to this change
None