### PR TITLE
feature: configure token expiration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ type TAuthConfig = {
   extraLogoutParameters?: { [key: string]: string | boolean | number } // default: null
   // Superseded by 'extraTokenParameters' options. Will be deprecated in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }  // default: null
+  // Can be used if auth provider doesn't return access token expiration time in token response
+  tokenExpiresIn?: number // default: null
+  // Can be used if auth provider doesn't return refresh token expiration time in token response
+  refreshTokenExpiresIn?: number // default: null
 }
 
 ```

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -88,9 +88,10 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   function handleTokenResponse(response: TTokenResponse) {
     setToken(response.access_token)
     setRefreshToken(response.refresh_token)
-    const tokenExpiresIn = response.expires_in ?? FALLBACK_EXPIRE_TIME
+    const tokenExpiresIn = config.tokenExpiresIn ?? response.expires_in ?? FALLBACK_EXPIRE_TIME
     setTokenExpire(epochAtSecondsFromNow(tokenExpiresIn))
-    setRefreshTokenExpire(epochAtSecondsFromNow(getRefreshExpiresIn(tokenExpiresIn, response)))
+    const refreshTokenExpiresIn = config.refreshTokenExpiresIn ?? getRefreshExpiresIn(tokenExpiresIn, response)
+    setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
     setIdToken(response.id_token)
     setLoginInProgress(false)
     try {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -68,6 +68,8 @@ export type TAuthConfig = {
   extraAuthParameters?: { [key: string]: string | boolean | number }
   extraTokenParameters?: { [key: string]: string | boolean | number }
   extraLogoutParameters?: { [key: string]: string | boolean | number }
+  tokenExpiresIn?: number
+  refreshTokenExpiresIn?: number
 }
 
 export type TRefreshTokenExpiredEvent = {
@@ -93,4 +95,6 @@ export type TInternalConfig = {
   extraAuthParameters?: { [key: string]: string | boolean | number }
   extraTokenParameters?: { [key: string]: string | boolean | number }
   extraLogoutParameters?: { [key: string]: string | boolean | number }
+  tokenExpiresIn?: number
+  refreshTokenExpiresIn?: number
 }


### PR DESCRIPTION
Some auth providers (like AzureAD) don't send information about access/refresh token expiration time in token response.

This change allows the user to provide access/refresh token expiration time via config.
## Example of usage

```tsx
import { AuthContext, AuthProvider, TAuthConfig, TRefreshTokenExpiredEvent } from "react-oauth2-code-pkce"

const authConfig: TAuthConfig = {
  ...
  tokenExpiresIn: 3600,
  refreshTokenExpiresIn: 86400 
}

const UserInfo = (): JSX.Element => {
    const {token, tokenData} = useContext<IAuthContext>(AuthContext)

    return <>
        <h4>Access Token</h4>
        <pre>{token}</pre>
        <h4>User Information from JWT</h4>
        <pre>{JSON.stringify(tokenData, null, 2)}</pre>
    </>
}

ReactDOM.render(<AuthProvider authConfig={authConfig}>
        <UserInfo/>
    </AuthProvider>
    , document.getElementById('root'),
)
```
