### PR TITLE
Feature/login with state

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ interface IAuthContext {
   token: string
   // An object with all the properties encoded in the token (username, email, etc.), if the token is a JWT 
   tokenData?: TTokenData
-  // Function to trigger login.
-  login: () => void  
+  // Function to trigger login. 
+  // If you want to use 'state', you might want to set 'clearURL' configuration parameter to 'false'.
+  login: (state?: string) => void  
   // Function to trigger logout from authentication provider. You may provide optional 'state', and 'logout_hint' values.
   // See https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout for details.
   logOut: (state?: string, logoutHint?: string) => void
@@ -119,6 +120,8 @@ type TAuthConfig = {
   redirectUri: string  // Required
   // Which scopes to request for the auth token
   scope?: string  // default: ''
+  // Optional state value. Will often make more sense to provide the state in a call to the 'login()' function
+  state?: string // default: null
   // Which URL to call for logging out of the auth provider
   logoutEndpoint?: string  // default: null
   // Which URL the auth provider should redirect the user to after logout
@@ -138,6 +141,8 @@ type TAuthConfig = {
   // By default, the package will automatically redirect the user to the login server if not already logged in.
   // If set to false, you need to call the "login()" function to login (e.g. with a "Login" button)
   autoLogin?: boolean  // default: true
+  // Set to false if you need to access the urlParameters sent back from the login server.
+  clearURL?: boolean  // default: true
   // Can be used to provide any non-standard parameters to the authentication request
   extraAuthParameters?: { [key: string]: string | boolean | number }  // default: null
   // Can be used to provide any non-standard parameters to the token request

--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -14,6 +14,12 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, (v: T) => void] {
   })
 
   const setValue = (value: T | ((val: T) => T)): void => {
+    if (!value) {
+      // Delete item if set to undefined. This avoids warning on loading invalid json
+      setStoredValue(value)
+      localStorage.removeItem(key)
+      return
+    }
     try {
       const valueToStore = value instanceof Function ? value(storedValue) : value
       setStoredValue(valueToStore)

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -41,7 +41,7 @@ export interface IAuthProvider {
 export interface IAuthContext {
   token: string
   logOut: (state?: string, logoutHint?: string) => void
-  login: () => void
+  login: (state?: string) => void
   error: string | null
   tokenData?: TTokenData
   idToken?: string
@@ -56,6 +56,7 @@ export type TAuthConfig = {
   tokenEndpoint: string
   redirectUri: string
   scope?: string
+  state?: string
   logoutEndpoint?: string
   logoutRedirect?: string
   preLogin?: () => void
@@ -63,6 +64,7 @@ export type TAuthConfig = {
   onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void
   decodeToken?: boolean
   autoLogin?: boolean
+  clearURL?: boolean
   // TODO: Remove in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }
   extraAuthParameters?: { [key: string]: string | boolean | number }
@@ -83,6 +85,7 @@ export type TInternalConfig = {
   tokenEndpoint: string
   redirectUri: string
   scope: string
+  state?: string
   logoutEndpoint?: string
   logoutRedirect?: string
   preLogin?: () => void
@@ -90,6 +93,7 @@ export type TInternalConfig = {
   onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void
   decodeToken: boolean
   autoLogin: boolean
+  clearURL: boolean
   // TODO: Remove in 2.0
   extraAuthParams?: { [key: string]: string | boolean | number }
   extraAuthParameters?: { [key: string]: string | boolean | number }

--- a/src/index.js
+++ b/src/index.js
@@ -8,20 +8,21 @@ import React, { useContext } from 'react'
 import { createRoot } from 'react-dom/client'
 import { AuthContext, AuthProvider } from './AuthContext'
 
+// Get auth provider info from "https://keycloak.ofstad.xyz/realms/master/.well-known/openid-configuration"
 const authConfig = {
-  clientId: '6559ce69-219d-4e82-b6ed-889a861c7c94',
-  authorizationEndpoint:
-    'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/authorize',
-  tokenEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/token',
-  Endpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/token',
-  logoutEndpoint: 'https://login.microsoftonline.com/d422398d-b6a5-454d-a202-7ed4c1bec457/oauth2/v2.0/logout',
+  clientId: 'account',
+  authorizationEndpoint: 'http://192.168.1.5:5555/realms/master/protocol/openid-connect/auth',
+  tokenEndpoint: 'http://192.168.1.5:5555/realms/master/protocol/openid-connect/token',
+  logoutEndpoint: 'http://192.168.1.5:5555/realms/master/protocol/openid-connect/logout',
   redirectUri: 'http://localhost:3000/',
   // preLogin: () => localStorage.setItem('preLoginPath', window.location.pathname),
   // postLogin: () => window.location.replace(localStorage.getItem('preLoginPath') || ''),
   onRefreshTokenExpire: (event) =>
     window.confirm('Tokens have expired. Refresh page to continue using the site?') && event.login(),
   decodeToken: true,
-  scope: 'User.read OpenId',
+  scope: 'profile openid',
+  // state: 'testState',
+  clearURL: true,
   autoLogin: false,
 }
 
@@ -91,7 +92,8 @@ function LoginInfo() {
       ) : (
         <>
           <div style={{ backgroundColor: 'red' }}>You are not logged in</div>
-          <button onClick={login}>Login</button>
+          <button onClick={() => login()}>Login</button>
+          <button onClick={() => login('customLoginState')}>Login w/state</button>
         </>
       )}
     </>

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,9 @@ import { AuthContext, AuthProvider } from './AuthContext'
 // Get auth provider info from "https://keycloak.ofstad.xyz/realms/master/.well-known/openid-configuration"
 const authConfig = {
   clientId: 'account',
-  authorizationEndpoint: 'http://192.168.1.5:5555/realms/master/protocol/openid-connect/auth',
-  tokenEndpoint: 'http://192.168.1.5:5555/realms/master/protocol/openid-connect/token',
-  logoutEndpoint: 'http://192.168.1.5:5555/realms/master/protocol/openid-connect/logout',
+  authorizationEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/auth',
+  tokenEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/token',
+  logoutEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/logout',
   redirectUri: 'http://localhost:3000/',
   // preLogin: () => localStorage.setItem('preLoginPath', window.location.pathname),
   // postLogin: () => window.location.replace(localStorage.getItem('preLoginPath') || ''),

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Provider agnostic react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/timeUtils.ts
+++ b/src/timeUtils.ts
@@ -6,11 +6,11 @@ export const epochAtSecondsFromNow = (secondsFromNow: number) => Math.round(Date
 
 /**
  * Check if the Access Token has expired.
- * Will return True if the token has expired, OR there is less than 5min until it expires.
+ * Will return True if the token has expired, OR there is less than 30 seconds until it expires.
  */
 export function epochTimeIsPast(timestamp: number): boolean {
   const now = Math.round(Date.now()) / 1000
-  const nowWithBuffer = now + 120
+  const nowWithBuffer = now + 30
   return nowWithBuffer >= timestamp
 }
 

--- a/tests/auth-request.test.tsx
+++ b/tests/auth-request.test.tsx
@@ -10,6 +10,7 @@ const authConfig: TAuthConfig = {
   tokenEndpoint: 'myTokenEndpoint',
   redirectUri: 'http://localhost:3000/',
   scope: 'someScope openid',
+  state: 'testState',
   extraAuthParameters: {
     prompt: true,
     client_id: 'anotherClientId',
@@ -37,7 +38,7 @@ describe('first page visit should redirect to auth provider for login', () => {
     await waitFor(() =>
       expect(window.location.replace).toHaveBeenCalledWith(
         expect.stringMatching(
-          /^myAuthEndpoint\?response_type=code&client_id=anotherClientId&scope=someScope\+openid&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&code_challenge=.{43}&code_challenge_method=S256&prompt=true/gm
+          /^myAuthEndpoint\?response_type=code&client_id=anotherClientId&scope=someScope\+openid&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&code_challenge=.{43}&code_challenge_method=S256&prompt=true&state=testState/gm
         )
       )
     )

--- a/tests/auth-util.test.ts
+++ b/tests/auth-util.test.ts
@@ -12,6 +12,7 @@ const authConfig: TInternalConfig = {
   tokenEndpoint: 'myTokenEndpoint',
   redirectUri: 'http://localhost:3000/',
   scope: 'someScope openid',
+  clearURL: false,
   extraAuthParams: {
     prompt: true,
     client_id: 'anotherClientId',

--- a/tests/token-request.test.tsx
+++ b/tests/token-request.test.tsx
@@ -46,7 +46,7 @@ describe('make token request with extra parameters', () => {
 
   // Setting up a state similar to what it would be just after redirect back from auth provider
   localStorage.setItem('ROCP_loginInProgress', 'true')
-  localStorage.setItem('PKCE_code_verifier', 'arandomstring')
+  sessionStorage.setItem('PKCE_code_verifier', 'arandomstring')
 
   it('calls the token endpoint with these parameters', async () => {
     // Have been redirected back with a code in query params


### PR DESCRIPTION
Support providing 'state' to the login()-function.
This is according to the RFC specificaltions.

As a consequence of this feature, if the user wants to
access the state being sent back from the login server,
we should not clear URL parameters. Added a optional config parameter for this.

Also;
  - codeVerifier is now written to sessionStorage
  - useLocalStorage no longer writes "nullish" values to store
  - "optimized" interval and time padding for "check if token is about to expire"

## Issues related to this change
closes #63 
