### PR TITLE
fix: move the `setLoginInProgress(false)`

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -95,7 +95,6 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     const refreshTokenExpiresIn = config.refreshTokenExpiresIn ?? getRefreshExpiresIn(tokenExpiresIn, response)
     setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
     setIdToken(response.id_token)
-    setLoginInProgress(false)
     try {
       if (config.decodeToken) setTokenData(decodeJWT(response.access_token))
       if (config.decodeToken && response.id_token) setIdTokenData(decodeJWT(response.id_token))
@@ -196,6 +195,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
               // Clear ugly url params
               window.history.replaceState(null, '', window.location.pathname)
             }
+            setLoginInProgress(false)
           })
       }
     } else if (!token) {


### PR DESCRIPTION
## What does this pull request change?
Moves the call to `setLoginInProgress(false)` from within a function call and out into a `.finally`-call, which is always run.

## Why is this pull request needed?
Current location could possibly not happen if the function call failed.

## Issues related to this change
None. Mentioned in https://github.com/soofstad/react-oauth2-pkce/pull/66#discussion_r1126259668