### PR TITLE
Add `setError(null)` to logOut function

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -79,6 +79,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
 
   function logOut(state?: string, logoutHint?: string) {
     clearStorage()
+    setError(null)
     if (config?.logoutEndpoint && refreshToken) redirectToLogout(config, refreshToken, idToken, state, logoutHint)
   }
 


### PR DESCRIPTION
## Why is this pull request needed, and what does it change?
Previously, errors were not cleared when logging out. I can not see a single case where it's helpful to keep errors after logging out. I'm (in my application) subscribing to the `error` state and showing a log-out button whenever it's not null, which currently doesn't do anything (it does log out, but the `error` state isn't cleared). 

This PR remedies that by clearing the error state when logging out.

## Issues related to this change
None.