### PR TITLE
fix: update expire interval on all relevant state changes

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -179,7 +179,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   useEffect(() => {
     interval = setInterval(() => refreshAccessToken(), 10000) // eslint-disable-line
     return () => clearInterval(interval)
-  }, [token]) // This token dependency removes the old, and registers a new Interval when a new token is fetched.
+  }, [token, refreshToken, refreshTokenExpire, tokenExpire]) // Replace the interval with a new when values used inside refreshAccessToken changes
 
   // This ref is used to make sure the 'fetchTokens' call is only made once.
   // Multiple calls with the same code will, and should, return an error from the API

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Provider agnostic react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What does this pull request change?
- Add all relevant state values to dependency array of "register-expire-check-interval-useEffect"

## Why is this pull request needed?
- On react versions < 18, "refreshAccessToken" would use "one-cycle" old values for all except "token".

## Issues related to this change
closes #75 