### PR TITLE
fix: always decode idToken

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -119,10 +119,14 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
     setIdToken(response.id_token)
     try {
-      if (config.decodeToken) setTokenData(decodeJWT(response.access_token))
-      if (config.decodeToken && response.id_token) setIdTokenData(decodeJWT(response.id_token))
+      if (response.id_token) setIdTokenData(decodeJWT(response.id_token))
     } catch (e) {
-      setError((e as Error).message)
+      console.warn(`Failed to decode idToken: ${(e as Error).message}`)
+    }
+    try {
+      if (config.decodeToken) setTokenData(decodeJWT(response.access_token))
+    } catch (e) {
+      console.warn(`Failed to decode access token: ${(e as Error).message}`)
     }
   }
 


### PR DESCRIPTION
## What does this pull request change?
- Always decode idToken

## Why is this pull request needed?
- idToken is always a JWT, per https://openid.net/specs/openid-connect-core-1_0.html#IDToken
  Therefore, we can always decode it. This allows for getting `idTokenData` even if the `accessToken` is not a JWT.

> **Note**
>Try catch on idToken decode _should_ not be needed. But this would potentially be a BREAKING CHANGE if we skipped it. And I think it's good to be forgiving with these "non-crucial" functionality.


## Issues related to this change
closes #74 