### PR TITLE
fix: if-clause should check for undefined

### DIFF
--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -16,7 +16,7 @@ function useBrowserStorage<T>(key: string, initialValue: T, type: 'session' | 'l
   })
 
   const setValue = (value: T | ((val: T) => T)): void => {
-    if (!value) {
+    if (value === undefined) {
       // Delete item if set to undefined. This avoids warning on loading invalid json
       setStoredValue(value)
       storage.removeItem(key)


### PR DESCRIPTION
Signed-off-by: Sebastian Vittersø <svit@equinor.com>

## What does this pull request change, and why is it needed?
We had a potential bug in `Hooks.tsx` where we only checked if `!value`, where `false` and `null` should not trigger, only `undefined`.

This is now changed to only trigger with `value === undefined`. 

## Issues related to this change
Closes #78.