### PR TITLE
fix: check and raise error for insecure context

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,18 @@
     "test:watch": "jest --silent --watch"
   },
   "devDependencies": {
-    "@testing-library/react": "^13.3.0",
-    "@types/jest": ">=27.4.1",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@types/jest": "^29.5.1",
     "@types/react": ">=17.0.21",
     "eslint": ">=8.22.0",
     "eslint-config-prettier": ">=8.5.0",
     "eslint-config-react-app": ">=7.0.1",
     "eslint-plugin-prettier": ">=4.2.1",
-    "jest": "^27.5.1",
-    "jest-environment-jsdom": "^27.5.1",
+    "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.5.0",
     "prettier": ">=2.7.1",
-    "ts-jest": "^27.1.4",
+    "ts-jest": "^29.1.0",
     "typescript": ">=4.6.4"
   },
   "browserslist": {

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -102,12 +102,17 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   function login(state?: string) {
     clearStorage()
     setLoginInProgress(true)
+    // TODO: Raise error on wrong state type in v2
+    let typeSafePassedState = state
     if (typeof state !== 'string') {
       console.warn(`Passed login state must be of type 'string'. Received '${state}'. Ignoring value...`)
-      redirectToLogin(config)
-      return
+      typeSafePassedState = undefined
     }
-    redirectToLogin(config, state)
+    redirectToLogin(config, typeSafePassedState).catch((error) => {
+      console.error(error)
+      setError(error.message)
+      setLoginInProgress(false)
+    })
   }
 
   function handleTokenResponse(response: TTokenResponse) {

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -11,13 +11,13 @@ import { postWithXForm } from './httpUtils'
 const codeVerifierStorageKey = 'PKCE_code_verifier'
 const stateStorageKey = 'ROCP_auth_state'
 
-export async function redirectToLogin(config: TInternalConfig, customState?: string) {
+export async function redirectToLogin(config: TInternalConfig, customState?: string): Promise<void> {
   // Create and store a random string in sessionStorage, used as the 'code_verifier'
   const codeVerifier = generateRandomString(96)
   sessionStorage.setItem(codeVerifierStorageKey, codeVerifier)
 
   // Hash and Base64URL encode the code_verifier, used as the 'code_challenge'
-  generateCodeChallenge(codeVerifier).then((codeChallenge) => {
+  return generateCodeChallenge(codeVerifier).then((codeChallenge) => {
     // Set query parameters and redirect user to OAuth2 authentication endpoint
     const params = new URLSearchParams({
       response_type: 'code',

--- a/src/pkceUtils.ts
+++ b/src/pkceUtils.ts
@@ -22,6 +22,11 @@ export function generateRandomString(length: number): string {
  *  PKCE Code Challenge = base64url(hash(codeVerifier))
  */
 export async function generateCodeChallenge(codeVerifier: string): Promise<string> {
+  if (!window.crypto.subtle?.digest) {
+    throw new Error(
+      "The context/environment is not secure, and does not support the 'crypto.subtle' module. See: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle for details"
+    )
+  }
   const encoder = new TextEncoder()
   const bytes: Uint8Array = encoder.encode(codeVerifier) // Encode the verifier to a byteArray
   const hash: ArrayBuffer = await window.crypto.subtle.digest('SHA-256', bytes) // sha256 hash it

--- a/tests/auth-request.test.tsx
+++ b/tests/auth-request.test.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import { AuthProvider } from '../src/AuthContext'
 import { TAuthConfig } from '../src/Types'
-import { act, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { AuthContext } from '../src'
 
 const authConfig: TAuthConfig = {
@@ -28,12 +28,12 @@ const AuthConsumer = () => {
 }
 
 describe('first page visit should redirect to auth provider for login', () => {
-  const wrapper = ({ children }: any) => <AuthProvider authConfig={authConfig}>{children}</AuthProvider>
-
   it('redirects with correct query params', async () => {
-    await act(async () => {
-      render(<AuthConsumer />, { wrapper })
-    })
+    render(
+      <AuthProvider authConfig={authConfig}>
+        <AuthConsumer />
+      </AuthProvider>
+    )
 
     await waitFor(() =>
       expect(window.location.replace).toHaveBeenCalledWith(

--- a/tests/insecure-environment.test.tsx
+++ b/tests/insecure-environment.test.tsx
@@ -1,0 +1,41 @@
+import React, { useContext } from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import { AuthContext, AuthProvider, TAuthConfig } from '../src'
+
+const authConfig: TAuthConfig = {
+  clientId: 'myClientID',
+  authorizationEndpoint: 'myAuthEndpoint',
+  tokenEndpoint: 'myTokenEndpoint',
+  redirectUri: 'http://localhost:3000/',
+  scope: 'someScope openid',
+}
+
+const AuthConsumer = () => {
+  const { error, loginInProgress } = useContext(AuthContext)
+  return (
+    <div>
+      {error && <div data-testid="error">{error}</div>}
+      <div data-testid="loginInProgress">{JSON.stringify(loginInProgress)}</div>
+    </div>
+  )
+}
+
+describe('Raise error on unsecure context', () => {
+  it('populates error state and stops login', async () => {
+    // @ts-ignore
+    global.crypto.subtle.digest = undefined
+    render(
+      <AuthProvider authConfig={authConfig}>
+        <AuthConsumer />
+      </AuthProvider>
+    )
+
+    const errorNode = await waitFor(() => screen.findByTestId('error'))
+
+    expect(errorNode).toHaveTextContent(
+      "The context/environment is not secure, and does not support the 'crypto.subtle' module. See: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle for details"
+    )
+    expect(screen.getByTestId('loginInProgress')).toHaveTextContent('false')
+  })
+})

--- a/tests/jestSetup.js
+++ b/tests/jestSetup.js
@@ -15,8 +15,5 @@ beforeAll(() => {
   // @ts-ignore
   window.location = location
 
-  window.crypto = {
-    subtle: nodeCrypto.webcrypto.subtle,
-    getRandomValues: nodeCrypto.webcrypto.getRandomValues.bind(nodeCrypto.webcrypto),
-  }
+  global.crypto.subtle = nodeCrypto.subtle
 })

--- a/tests/token-request.test.tsx
+++ b/tests/token-request.test.tsx
@@ -42,8 +42,6 @@ const AuthConsumer = () => {
 }
 
 describe('make token request with extra parameters', () => {
-  const wrapper = ({ children }: any) => <AuthProvider authConfig={authConfig}>{children}</AuthProvider>
-
   // Setting up a state similar to what it would be just after redirect back from auth provider
   localStorage.setItem('ROCP_loginInProgress', 'true')
   sessionStorage.setItem('PKCE_code_verifier', 'arandomstring')
@@ -52,9 +50,11 @@ describe('make token request with extra parameters', () => {
     // Have been redirected back with a code in query params
     window.location.search = '?code=1234'
 
-    await act(async () => {
-      render(<AuthConsumer />, { wrapper })
-    })
+    render(
+      <AuthProvider authConfig={authConfig}>
+        <AuthConsumer />
+      </AuthProvider>
+    )
 
     await waitFor(() =>
       expect(fetch).toHaveBeenCalledWith('myTokenEndpoint', {


### PR DESCRIPTION
## What does this pull request change?
- Create a check for availability of `crypto.subtle` and throw error if missing
- Update testing dependencies
- Remove unnecessary context wrapper in tests
- Added test for "unsecure-environment"

## Why is this pull request needed?
see #73 

## Issues related to this change
closes #73 