### PR TITLE
Fixed issue #92 Concurrent fetchTokens and autoLogin trigger

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -217,8 +217,8 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
             }
             setLoginInProgress(false)
           })
-        return
       }
+      return
     }
 
     // First page visit


### PR DESCRIPTION
## What does this pull request change?
This PR prevents concurrent fetchTokens call (after OAuth return) and autoLogin 

## Why is this pull request needed?
In v1.13.4 the effect has been changed, where the return is not in the correct scope

## Issues related to this change
This PR fixes issue #92
