### PR TITLE
fix: use `location.assign()` instead of `location.replace()`, to enable browser history usage

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -40,7 +40,7 @@ export async function redirectToLogin(config: TInternalConfig, customState?: str
     }
     // Call any preLogin function in authConfig
     if (config?.preLogin) config.preLogin()
-    window.location.replace(`${config.authorizationEndpoint}?${params.toString()}`)
+    window.location.assign(`${config.authorizationEndpoint}?${params.toString()}`)
   })
 }
 
@@ -125,8 +125,7 @@ export function redirectToLogout(
   if (idToken) params.append('id_token_hint', idToken)
   if (state) params.append('state', state)
   if (logoutHint) params.append('logout_hint', logoutHint)
-
-  window.location.replace(`${config.logoutEndpoint}?${params.toString()}`)
+  window.location.assign(`${config.logoutEndpoint}?${params.toString()}`)
 }
 
 export function validateState(urlParams: URLSearchParams) {

--- a/tests/jestSetup.js
+++ b/tests/jestSetup.js
@@ -15,6 +15,6 @@ beforeEach(() => {
   // biome-ignore lint: set undefine does not work...
   delete window.location
   const location = new URL('https://www.example.com')
-  location.replace = jest.fn()
+  location.assign = jest.fn()
   window.location = location
 })

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -12,7 +12,7 @@ test('First page visit should redirect to auth provider for login', async () => 
   )
 
   await waitFor(() => {
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(window.location.assign).toHaveBeenCalledWith(
       expect.stringMatching(
         /^myAuthEndpoint\?response_type=code&client_id=myClientID&redirect_uri=http%3A%2F%2Flocalhost%2F&code_challenge=.{43}&code_challenge_method=S256&scope=someScope\+openid&state=testState/gm
       )

--- a/tests/logout.test.tsx
+++ b/tests/logout.test.tsx
@@ -19,11 +19,11 @@ test('Full featured logout requests', async () => {
   await user.click(screen.getByText('Logout'))
 
   await waitFor(() =>
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(window.location.assign).toHaveBeenCalledWith(
       'myLogoutEndpoint?token=test-refresh-value&token_type_hint=refresh_token&client_id=myClientID&post_logout_redirect_uri=primary-logout-redirect&ui_locales=en-US+en&testLogoutKey=logoutValue&state=logoutState'
     )
   )
-  expect(window.location.replace).toHaveBeenCalledTimes(1)
+  expect(window.location.assign).toHaveBeenCalledTimes(1)
 })
 
 test('No refresh token, no logoutRedirect, logout request', async () => {
@@ -41,9 +41,9 @@ test('No refresh token, no logoutRedirect, logout request', async () => {
   await user.click(screen.getByText('Logout'))
 
   await waitFor(() =>
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(window.location.assign).toHaveBeenCalledWith(
       'myLogoutEndpoint?token=test-token-value&token_type_hint=access_token&client_id=myClientID&post_logout_redirect_uri=http%3A%2F%2Flocalhost%2F&ui_locales=en-US+en&testLogoutKey=logoutValue&state=logoutState'
     )
   )
-  expect(window.location.replace).toHaveBeenCalledTimes(1)
+  expect(window.location.assign).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
## What does this pull request change?
Replaces `window.location.replace(newUrl)` with `window.location.assign(newUrl)` two places in `authentication.ts` and in the related test setup.

## Why is this pull request needed?
This change allows users to hit the browser's back-button (or hardware back-buttons) to get back to the page they were on before they were redirected to the auth-provider's login page.

## Issues related to this change
Closes #97 closes #134.