### PR TITLE
fix: make scope optional and don't send it if undefined

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 
 interface TTokenRqBase {
   grant_type: string
-  scope: string
+  scope?: string
   client_id: string
   redirect_uri: string
 }
@@ -85,7 +85,7 @@ export type TInternalConfig = {
   authorizationEndpoint: string
   tokenEndpoint: string
   redirectUri: string
-  scope: string
+  scope?: string
   state?: string
   logoutEndpoint?: string
   logoutRedirect?: string

--- a/src/authConfig.ts
+++ b/src/authConfig.ts
@@ -11,7 +11,7 @@ export function createInternalConfig(passedConfig: TAuthConfig): TInternalConfig
     autoLogin = true,
     clearURL = true,
     decodeToken = true,
-    scope = '',
+    scope = undefined,
     preLogin = () => null,
     postLogin = () => null,
     onRefreshTokenExpire = undefined,

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -22,12 +22,15 @@ export async function redirectToLogin(config: TInternalConfig, customState?: str
     const params = new URLSearchParams({
       response_type: 'code',
       client_id: config.clientId,
-      scope: config.scope,
       redirect_uri: config.redirectUri,
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       ...config.extraAuthParameters,
     })
+
+    if (config.scope !== undefined) {
+      params.append('scope', config.scope)
+    }
 
     sessionStorage.removeItem(stateStorageKey)
     const state = customState ?? config.state

--- a/tests/login.test.tsx
+++ b/tests/login.test.tsx
@@ -14,7 +14,7 @@ test('First page visit should redirect to auth provider for login', async () => 
   await waitFor(() => {
     expect(window.location.replace).toHaveBeenCalledWith(
       expect.stringMatching(
-        /^myAuthEndpoint\?response_type=code&client_id=myClientID&scope=someScope\+openid&redirect_uri=http%3A%2F%2Flocalhost%2F&code_challenge=.{43}&code_challenge_method=S256&state=testState/gm
+        /^myAuthEndpoint\?response_type=code&client_id=myClientID&redirect_uri=http%3A%2F%2Flocalhost%2F&code_challenge=.{43}&code_challenge_method=S256&scope=someScope\+openid&state=testState/gm
       )
     )
   })


### PR DESCRIPTION
## What does this pull request change?
Makes the `scope` property internally optional as well (optional = allowed to be `undefined`). Also hides it from requests if it's set to `undefined`, as per the spec.

## Why is this pull request needed?
We didn't adhere to the spec. Now we do (more closely at least). 


## Issues related to this change
Closes #96.