### PR TITLE
Fix error message to JSON Web Token

### DIFF
--- a/src/decodeJWT.ts
+++ b/src/decodeJWT.ts
@@ -19,7 +19,7 @@ export const decodeJWT = (token: string): TTokenData => {
   } catch (e) {
     console.error(e)
     throw Error(
-      'Failed to decode the access token.\n\tIs it a proper Java Web Token?\n\t' +
+      'Failed to decode the access token.\n\tIs it a proper JSON Web Token?\n\t' +
         "You can disable JWT decoding by setting the 'decodeToken' value to 'false' the configuration."
     )
   }


### PR DESCRIPTION
## What does this pull request change?
Fix the error message about JWT => JSON Web Token rather than Java Web Token

## Why is this pull request needed?
Better error message

## Issues related to this change
No issue needed