### PR TITLE
fix: disable decoding undefined token

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,17 +4,7 @@
     "es2021": true,
     "node": true
   },
-  "extends": [
-    "react-app",
-    "react-app/jest",
-    "eslint:recommended",
-    "plugin:react/recommended",
-    "plugin:react/jsx-runtime",
-    "plugin:jsx-a11y/recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier"
-  ],
-  "parser": "@typescript-eslint/parser",
+  "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:@typescript-eslint/recommended"],
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true
@@ -23,12 +13,9 @@
     "sourceType": "module"
   },
   "root": true,
-  "plugins": ["react", "@typescript-eslint", "react-hooks", "jsx-a11y", "eslint-plugin-prettier"],
+  "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
     "react/boolean-prop-naming": "warn",
-    "prettier/prettier": "error",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off"
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
+  "root": true,
   "plugins": ["react", "@typescript-eslint", "react-hooks", "jsx-a11y", "eslint-plugin-prettier"],
   "rules": {
     "react-hooks/rules-of-hooks": "error",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
         args: [--fix]
         additional_dependencies:
           - eslint
-          - eslint-config-react-app
           - typescript
           - "@typescript-eslint/parser"
           - "@typescript-eslint/eslint-plugin"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@types/react": ">=17.0.21",
     "eslint": ">=8.22.0",
     "eslint-config-prettier": ">=8.5.0",
-    "eslint-config-react-app": ">=7.0.1",
     "eslint-plugin-prettier": ">=4.2.1",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -241,7 +241,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
       console.warn(`Failed to decode idToken: ${(e as Error).message}`)
     }
     try {
-      if (config.decodeToken) setTokenData(decodeJWT(token))
+      if (token && config.decodeToken) setTokenData(decodeJWT(token))
     } catch (e) {
       console.warn(`Failed to decode access token: ${(e as Error).message}`)
     }

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -37,7 +37,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     config.storage,
     config.storageKeyPrefix
   )
-  const [token, setToken] = useBrowserStorage<string>('ROCP_token', '', config.storage, config.storageKeyPrefix)
+  const [token, setToken] = useBrowserStorage<string>('token', '', config.storage, config.storageKeyPrefix)
   const [tokenExpire, setTokenExpire] = useBrowserStorage<number>(
     'tokenExpire',
     epochAtSecondsFromNow(FALLBACK_EXPIRE_TIME),

--- a/tests/jestSetup.js
+++ b/tests/jestSetup.js
@@ -10,7 +10,7 @@ beforeEach(() => {
   global.TextEncoder = TextEncoder
   global.TextDecoder = TextDecoder
 
-  global.crypto.subtle = nodeCrypto.webcrypto.subtle;
+  global.crypto.subtle = nodeCrypto.webcrypto.subtle
 
   delete window.location
   const location = new URL('https://www.example.com')


### PR DESCRIPTION
## What does this pull request change?
Adds a check to `setTokenData(decodeJWT(token))` to verify that `token !== undefined` when doing it.

## Why is this pull request needed?
The console retrieves two errors and two warnings during startup if the user isn't logged in. Not pretty.

## Issues related to this change
None.