### PR TITLE
feat: allow expire times as strings

### DIFF
--- a/src/timeUtils.ts
+++ b/src/timeUtils.ts
@@ -2,7 +2,9 @@ import { TTokenResponse } from './Types'
 export const FALLBACK_EXPIRE_TIME = 600 // 10minutes
 
 // Returns epoch time (in seconds) for when the token will expire
-export const epochAtSecondsFromNow = (secondsFromNow: number) => Math.round(Date.now() / 1000 + secondsFromNow)
+// 'secondsFromNow' should always be an integer, but some auth providers has decided that whole numbers should be strings...
+export const epochAtSecondsFromNow = (secondsFromNow: number | string) =>
+  Math.round(Date.now() / 1000 + Number(secondsFromNow))
 
 /**
  * Check if the Access Token has expired.

--- a/tests/auth-util.test.ts
+++ b/tests/auth-util.test.ts
@@ -51,6 +51,18 @@ test('check if still valid token inside buffer has expired', () => {
   expect(hasExpired).toBe(true)
 })
 
+test('expire time as string gets correctly converted', () => {
+  const expectedEpoch = Math.round(Date.now() / 1000 + 55555)
+  const epochSumCalculated = epochAtSecondsFromNow('55555')
+  expect(expectedEpoch).toBe(epochSumCalculated)
+})
+
+test('expire time as int gets correctly converted', () => {
+  const expectedEpoch = Math.round(Date.now() / 1000 + 55555)
+  const epochSumCalculated = epochAtSecondsFromNow(55555)
+  expect(expectedEpoch).toBe(epochSumCalculated)
+})
+
 test('check if still valid token outside buffer has expired', () => {
   const willExpireAt = epochAtSecondsFromNow(301) // Will expire in 5min
   const hasExpired = epochTimeIsPast(willExpireAt)


### PR DESCRIPTION
## What does this pull request change?
Attempt to convert recieved "expire_time" to Number.

## Why is this pull request needed?
Some auth providers might respond with a string instead of Number for the "expires_in_*" value.

## Issues related to this change
closes #111 