### PR TITLE
The token request should not include the scope parameter

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -12,6 +12,7 @@ export interface TTokenRequestWithCodeAndVerifier extends TTokenRqBase {
 }
 
 export interface TTokenRequestForRefresh extends TTokenRqBase {
+  scope?: string
   refresh_token: string
 }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 
 interface TTokenRqBase {
   grant_type: string
-  scope?: string
   client_id: string
   redirect_uri: string
 }

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -81,7 +81,6 @@ export const fetchTokens = (config: TInternalConfig): Promise<TTokenResponse> =>
   const tokenRequest: TTokenRequestWithCodeAndVerifier = {
     grant_type: 'authorization_code',
     code: authCode,
-    scope: config.scope,
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
     code_verifier: codeVerifier,

--- a/tests/get_token.test.tsx
+++ b/tests/get_token.test.tsx
@@ -33,7 +33,7 @@ test('make token request with extra parameters', async () => {
 
   await waitFor(() =>
     expect(fetch).toHaveBeenCalledWith('myTokenEndpoint', {
-      body: 'grant_type=authorization_code&code=1234&scope=someScope%20openid&client_id=anotherClientId&redirect_uri=http%3A%2F%2Flocalhost%2F&code_verifier=arandomstring&testTokenKey=tokenValue',
+      body: 'grant_type=authorization_code&code=1234&client_id=anotherClientId&redirect_uri=http%3A%2F%2Flocalhost%2F&code_verifier=arandomstring&testTokenKey=tokenValue',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },


### PR DESCRIPTION
The scope parameter is not indicated in RFC7636 for inclusion in the token request. It should be removed as it causes issues with strict IDP implementations.

## What does this pull request change?

Removes "scope" parameter from token request

## Why is this pull request needed?

Including "scope" is a specification violation

## Issues related to this change

https://github.com/soofstad/react-oauth2-pkce/issues/129
