### PR TITLE
feat: option to opt-out of sending scope with refresh request

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ type TAuthConfig = {
   tokenExpiresIn?: number // default: null
   // Can be used if auth provider doesn't return refresh token expiration time in token response
   refreshTokenExpiresIn?: number // default: null
+  // Whether or not to post 'scope' when refreshing the access token
+  refreshWithScope?: boolean // default: true
 }
 
 ```

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -74,6 +74,7 @@ export type TAuthConfig = {
   refreshTokenExpiresIn?: number
   storage?: 'session' | 'local'
   storageKeyPrefix?: string
+  refreshWithScope?: boolean
 }
 
 export type TRefreshTokenExpiredEvent = {
@@ -105,4 +106,5 @@ export type TInternalConfig = {
   refreshTokenExpiresIn?: number
   storage: 'session' | 'local'
   storageKeyPrefix: string
+  refreshWithScope: boolean
 }

--- a/src/authConfig.ts
+++ b/src/authConfig.ts
@@ -17,6 +17,7 @@ export function createInternalConfig(passedConfig: TAuthConfig): TInternalConfig
     onRefreshTokenExpire = undefined,
     storage = 'local',
     storageKeyPrefix = 'ROCP_',
+    refreshWithScope = true,
   }: TAuthConfig = passedConfig
 
   const config: TInternalConfig = {
@@ -30,6 +31,7 @@ export function createInternalConfig(passedConfig: TAuthConfig): TInternalConfig
     onRefreshTokenExpire: onRefreshTokenExpire,
     storage: storage,
     storageKeyPrefix: storageKeyPrefix,
+    refreshWithScope: refreshWithScope,
   }
   validateConfig(config)
   return config

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -99,11 +99,11 @@ export const fetchWithRefreshToken = (props: {
   const refreshRequest: TTokenRequestForRefresh = {
     grant_type: 'refresh_token',
     refresh_token: refreshToken,
-    scope: config.scope,
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
     ...config.extraTokenParameters,
   }
+  if (config.refreshWithScope) refreshRequest.scope = config.scope
   return postTokenRequest(config.tokenEndpoint, refreshRequest)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const authConfig = {
   clearURL: true,
   autoLogin: false,
   storage: 'local',
+  refreshWithScope: false,
 }
 
 function LoginInfo() {
@@ -38,6 +39,10 @@ function LoginInfo() {
       {token ? (
         <>
           <button onClick={() => logOut('rememberThis', idTokenData.tid)}>Logout</button>
+          <span style={{ margin: '0 10px' }}>
+            Access token will expire at:{' '}
+            {new Date(localStorage.getItem('ROCP_tokenExpire') * 1000).toLocaleTimeString()}
+          </span>
           <div style={{ display: 'flex', flexWrap: 'wrap' }}>
             <div>
               <h4>Access Token (JWT)</h4>

--- a/tests/auth-util.test.ts
+++ b/tests/auth-util.test.ts
@@ -15,6 +15,7 @@ const authConfig: TInternalConfig = {
   clearURL: false,
   storage: 'local',
   storageKeyPrefix: 'ROCP_',
+  refreshWithScope: true,
   extraAuthParams: {
     prompt: true,
     client_id: 'anotherClientId',


### PR DESCRIPTION
## What does this pull request change?
Adds a config parameter to opt-out of sending "scope" in the refresh request.

## Why is this pull request needed?
- Some auth servers will throw an error if the "scope" parameter is in the refresh request

## Issues related to this change
relates to issues raised in #129 