### PR TITLE
Feature/get exp from decoded token

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -12,7 +12,13 @@ import { createInternalConfig } from './authConfig'
 import { fetchTokens, fetchWithRefreshToken, redirectToLogin, redirectToLogout, validateState } from './authentication'
 import { decodeJWT } from './decodeJWT'
 import { FetchError } from './errors'
-import { FALLBACK_EXPIRE_TIME, epochAtSecondsFromNow, epochTimeIsPast, getExpFromJWTToken, getRefreshExpiresIn } from './timeUtils'
+import {
+  FALLBACK_EXPIRE_TIME,
+  epochAtSecondsFromNow,
+  epochTimeIsPast,
+  getExpiresInFromJWTToken,
+  getRefreshExpiresIn
+} from './timeUtils'
 
 export const AuthContext = createContext<IAuthContext>({
   token: '',
@@ -98,7 +104,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     setRefreshToken(response.refresh_token)
     const tokenExpiresIn = config.tokenExpiresIn
       ?? response.expires_in
-      ?? getExpFromJWTToken(response.id_token)
+      ?? getExpiresInFromJWTToken(response.id_token)
       ?? FALLBACK_EXPIRE_TIME
     setTokenExpire(epochAtSecondsFromNow(tokenExpiresIn))
     const refreshTokenExpiresIn = config.refreshTokenExpiresIn ?? getRefreshExpiresIn(tokenExpiresIn, response)

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -12,7 +12,7 @@ import { createInternalConfig } from './authConfig'
 import { fetchTokens, fetchWithRefreshToken, redirectToLogin, redirectToLogout, validateState } from './authentication'
 import { decodeJWT } from './decodeJWT'
 import { FetchError } from './errors'
-import { FALLBACK_EXPIRE_TIME, epochAtSecondsFromNow, epochTimeIsPast, getRefreshExpiresIn } from './timeUtils'
+import { FALLBACK_EXPIRE_TIME, epochAtSecondsFromNow, epochTimeIsPast, getExpFromJWTToken, getRefreshExpiresIn } from './timeUtils'
 
 export const AuthContext = createContext<IAuthContext>({
   token: '',
@@ -96,7 +96,10 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   function handleTokenResponse(response: TTokenResponse) {
     setToken(response.access_token)
     setRefreshToken(response.refresh_token)
-    const tokenExpiresIn = config.tokenExpiresIn ?? response.expires_in ?? FALLBACK_EXPIRE_TIME
+    const tokenExpiresIn = config.tokenExpiresIn
+      ?? response.expires_in
+      ?? getExpFromJWTToken(response.id_token)
+      ?? FALLBACK_EXPIRE_TIME
     setTokenExpire(epochAtSecondsFromNow(tokenExpiresIn))
     const refreshTokenExpiresIn = config.refreshTokenExpiresIn ?? getRefreshExpiresIn(tokenExpiresIn, response)
     setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -17,7 +17,7 @@ import {
   epochAtSecondsFromNow,
   epochTimeIsPast,
   getExpiresInFromJWTToken,
-  getRefreshExpiresIn
+  getRefreshExpiresIn,
 } from './timeUtils'
 
 export const AuthContext = createContext<IAuthContext>({
@@ -102,10 +102,11 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   function handleTokenResponse(response: TTokenResponse) {
     setToken(response.access_token)
     setRefreshToken(response.refresh_token)
-    const tokenExpiresIn = config.tokenExpiresIn
-      ?? response.expires_in
-      ?? getExpiresInFromJWTToken(response.id_token)
-      ?? FALLBACK_EXPIRE_TIME
+    const tokenExpiresIn =
+      config.tokenExpiresIn ??
+      response.expires_in ??
+      getExpiresInFromJWTToken(response.id_token) ??
+      FALLBACK_EXPIRE_TIME
     setTokenExpire(epochAtSecondsFromNow(tokenExpiresIn))
     const refreshTokenExpiresIn = config.refreshTokenExpiresIn ?? getRefreshExpiresIn(tokenExpiresIn, response)
     setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -12,13 +12,7 @@ import { createInternalConfig } from './authConfig'
 import { fetchTokens, fetchWithRefreshToken, redirectToLogin, redirectToLogout, validateState } from './authentication'
 import { decodeJWT } from './decodeJWT'
 import { FetchError } from './errors'
-import {
-  FALLBACK_EXPIRE_TIME,
-  epochAtSecondsFromNow,
-  epochTimeIsPast,
-  getExpiresInFromJWTToken,
-  getRefreshExpiresIn,
-} from './timeUtils'
+import { FALLBACK_EXPIRE_TIME, epochAtSecondsFromNow, epochTimeIsPast, getRefreshExpiresIn } from './timeUtils'
 
 export const AuthContext = createContext<IAuthContext>({
   token: '',
@@ -102,20 +96,21 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   function handleTokenResponse(response: TTokenResponse) {
     setToken(response.access_token)
     setRefreshToken(response.refresh_token)
-    const tokenExpiresIn =
-      config.tokenExpiresIn ??
-      response.expires_in ??
-      getExpiresInFromJWTToken(response.id_token) ??
-      FALLBACK_EXPIRE_TIME
+    let tokenExp = FALLBACK_EXPIRE_TIME
+    try {
+      if (response.id_token) {
+        const decodedToken = decodeJWT(response.id_token)
+        setIdTokenData(decodedToken)
+        tokenExp = Math.round(Number(decodedToken.exp) - Date.now() / 1000) // number of seconds from now
+      }
+    } catch (e) {
+      console.warn(`Failed to decode idToken: ${(e as Error).message}`)
+    }
+    const tokenExpiresIn = config.tokenExpiresIn ?? response.expires_in ?? tokenExp
     setTokenExpire(epochAtSecondsFromNow(tokenExpiresIn))
     const refreshTokenExpiresIn = config.refreshTokenExpiresIn ?? getRefreshExpiresIn(tokenExpiresIn, response)
     setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
     setIdToken(response.id_token)
-    try {
-      if (response.id_token) setIdTokenData(decodeJWT(response.id_token))
-    } catch (e) {
-      console.warn(`Failed to decode idToken: ${(e as Error).message}`)
-    }
     try {
       if (config.decodeToken) setTokenData(decodeJWT(response.access_token))
     } catch (e) {

--- a/src/timeUtils.ts
+++ b/src/timeUtils.ts
@@ -1,5 +1,4 @@
 import { TTokenResponse } from './Types'
-import { decodeJWT } from './decodeJWT'
 export const FALLBACK_EXPIRE_TIME = 600 // 10minutes
 
 // Returns epoch time (in seconds) for when the token will expire
@@ -30,16 +29,4 @@ export function getRefreshExpiresIn(tokenExpiresIn: number, response: TTokenResp
   if (response.refresh_token) return tokenExpiresIn + FALLBACK_EXPIRE_TIME
   // The token response had no refresh_token. Set refresh_expire equals to access_token expire
   return tokenExpiresIn
-}
-
-export function getExpiresInFromJWTToken(idToken: string | undefined): number | undefined {
-  if (idToken) {
-    try {
-      const decodedToken = decodeJWT(idToken)
-      return Math.round(Number(decodedToken.exp) - Date.now() / 1000)
-    } catch (error) {
-      // idToken was not a JWT
-      return
-    }
-  }
 }

--- a/src/timeUtils.ts
+++ b/src/timeUtils.ts
@@ -32,11 +32,11 @@ export function getRefreshExpiresIn(tokenExpiresIn: number, response: TTokenResp
   return tokenExpiresIn
 }
 
-export function getExpFromJWTToken(idToken: string | undefined): number | undefined {
+export function getExpiresInFromJWTToken(idToken: string | undefined): number | undefined {
   if (idToken) {
     try {
       const decodedToken = decodeJWT(idToken)
-      return decodedToken.exp
+      return Math.round(Number(decodedToken.exp) - Date.now() / 1000)
     } catch (error) {
       // idToken was not a JWT
       return

--- a/src/timeUtils.ts
+++ b/src/timeUtils.ts
@@ -1,4 +1,5 @@
 import { TTokenResponse } from './Types'
+import { decodeJWT } from './decodeJWT'
 export const FALLBACK_EXPIRE_TIME = 600 // 10minutes
 
 // Returns epoch time (in seconds) for when the token will expire
@@ -29,4 +30,16 @@ export function getRefreshExpiresIn(tokenExpiresIn: number, response: TTokenResp
   if (response.refresh_token) return tokenExpiresIn + FALLBACK_EXPIRE_TIME
   // The token response had no refresh_token. Set refresh_expire equals to access_token expire
   return tokenExpiresIn
+}
+
+export function getExpFromJWTToken(idToken: string | undefined): number | undefined {
+  if (idToken) {
+    try {
+      const decodedToken = decodeJWT(idToken)
+      return decodedToken.exp
+    } catch (error) {
+      // idToken was not a JWT
+      return
+    }
+  }
 }


### PR DESCRIPTION
## What does this pull request change?
Add token `exp` claim as an additional fallback for determining token expiration

## Why is this pull request needed?
Some IdPs don't provide the `expires_in` field on token response

## Issues related to this change
https://github.com/soofstad/react-oauth2-pkce/issues/135
