### PR TITLE
fix: handle token response with no refresh_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,19 @@ type TAuthConfig = {
 
 ## Common issues
 
+### Sessions expire too quickly
+
+A session expire happens when the `refresh_token` is no longer valid and can't be used to fetch a new valid `access_token`.
+This is governed by the `expires_in`, and `refresh_expires_in | refresh_token_expires_in`, in the token response.
+If the response does not contain these values, the library assumes a quite conservative value. 
+You should configure your IDP (Identity Provider) to send these, but if that is not possible, you can set them explicitly
+with the config parameters `tokenExpiresIn` and `refreshTokenExpiresIn`.
+
+### Fails to compile with Next.js
+
+This library expects to have a `localStorage` available. That is not the case when compiling Next.js projects serverside.  
+See: https://github.com/soofstad/react-oauth2-pkce/discussions/90 for a solution.
+
 ### After redirect back from auth provider with `?code`, no token request is made
 
 If you are using libraries that intercept any `fetch()`-requests made. For example `@tanstack/react-query`. That can cause

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -95,8 +95,8 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
 
   function handleTokenResponse(response: TTokenResponse) {
     setToken(response.access_token)
-    setRefreshToken(response.refresh_token)
     let tokenExp = FALLBACK_EXPIRE_TIME
+    // Decode IdToken, so we can use "exp" from that as fallback if expire not returned in the response
     try {
       if (response.id_token) {
         const decodedToken = decodeJWT(response.id_token)
@@ -109,7 +109,10 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     const tokenExpiresIn = config.tokenExpiresIn ?? response.expires_in ?? tokenExp
     setTokenExpire(epochAtSecondsFromNow(tokenExpiresIn))
     const refreshTokenExpiresIn = config.refreshTokenExpiresIn ?? getRefreshExpiresIn(tokenExpiresIn, response)
-    setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
+    if (response.refresh_token) {
+      setRefreshToken(response.refresh_token)
+      setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
+    }
     setIdToken(response.id_token)
     try {
       if (config.decodeToken) setTokenData(decodeJWT(response.access_token))

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Provider agnostic react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What does this pull request change?
- Don't assume that refresh_token is always included in token response.
- Added some more "Common issues" in README

## Why is this pull request needed?
Some IDPs don't include refresh_token when requesting a token with a refresh_token

## Issues related to this change
closes #137 