### PR TITLE
feat: use selected storage for auth state and code verifier (too)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,22 +181,18 @@ with the config parameters `tokenExpiresIn` and `refreshTokenExpiresIn`.
 
 ### Fails to compile with Next.js
 
-This library expects to have a `localStorage` available. That is not the case when compiling Next.js projects serverside.  
+This library expects to have a `localStorage` (or `sessionStorage`) available. That is not the case when compiling Next.js projects serverside.  
 See: https://github.com/soofstad/react-oauth2-pkce/discussions/90 for a solution.
 
 ### Error `Bad authorization state...`
 
-This is most likely to happen if the authentication at the identity
-provider got aborted in some way.
+This is most likely to happen if the authentication at the identity provider got aborted in some way.
 You might also see the error `Expected  to find a '?code=' parameter in the URL by now. Did the authentication get aborted or interrupted?` in the console.
 
 First of all, you should handle any errors the library throws. Usually, hinting at the user reload the page is enough.
 
-Some known causes for this is that instead of logging in at the 
-auth provider, the user "Registers" or "Reset password" or 
-something similar instead. Any such functions should be handled 
-outside of this library, with separate buttons/links than the 
-Login-button.
+Some known causes for this is that instead of logging in at the auth provider, the user "Registers" or "Reset password" or 
+something similar instead. Any such functions should be handled outside of this library, with separate buttons/links than the Login-button.
 
 ### After redirect back from auth provider with `?code`, no token request is made
 

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -221,7 +221,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
       if (!didFetchTokens.current) {
         didFetchTokens.current = true
         try {
-          validateState(urlParams)
+          validateState(urlParams, config.storage)
         } catch (e: unknown) {
           console.error(e)
           setError((e as Error).message)

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -187,9 +187,11 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     )
   }
 
-  // Register the 'check for soon expiring access token' interval (Every 10 seconds)
+  // Register the 'check for soon expiring access token' interval (every ~10 seconds).
   useEffect(() => {
-    const interval = setInterval(() => refreshAccessToken(), 10000) // eslint-disable-line
+    // The randomStagger is used to avoid multiple tabs logging in at the exact same time.
+    const randomStagger = 10000 * Math.random()
+    const interval = setInterval(() => refreshAccessToken(), 5000 + randomStagger) // eslint-disable-line
     return () => clearInterval(interval)
   }, [token, refreshToken, refreshTokenExpire, tokenExpire]) // Replace the interval with a new when values used inside refreshAccessToken changes
 

--- a/src/Hooks.tsx
+++ b/src/Hooks.tsx
@@ -25,14 +25,22 @@ function useBrowserStorage<T>(key: string, initialValue: T, type: 'session' | 'l
       setStoredValue(valueToStore)
       storage.setItem(key, JSON.stringify(valueToStore))
     } catch (error) {
-      console.log(`Failed to store value '${value}' for key '${key}'`)
+      console.error(`Failed to store value '${value}' for key '${key}'`)
     }
   }
 
   useEffect(() => {
     const storageEventHandler = (event: StorageEvent) => {
       if (event.storageArea === storage && event.key === key) {
-        setStoredValue(JSON.parse(event.newValue ?? '') as T)
+        if (event.newValue === null) {
+          setStoredValue(undefined as T)
+        } else {
+          try {
+            setStoredValue(JSON.parse(event.newValue ?? '') as T)
+          } catch (error: unknown) {
+            console.warn(`Failed to handle storageEvent's newValue='${event.newValue}' for key '${key}'`)
+          }
+        }
       }
     }
     window.addEventListener('storage', storageEventHandler, false)

--- a/tests/get_token.test.tsx
+++ b/tests/get_token.test.tsx
@@ -22,7 +22,7 @@ global.fetch = jest.fn(() =>
 test('make token request with extra parameters', async () => {
   // Setting up a state similar to what it would be just after redirect back from auth provider
   localStorage.setItem('ROCP_loginInProgress', 'true')
-  sessionStorage.setItem('PKCE_code_verifier', 'arandomstring')
+  localStorage.setItem('PKCE_code_verifier', 'arandomstring')
   window.location.search = '?code=1234'
 
   render(


### PR DESCRIPTION
## What does this pull request change?

First adds a `randomStagger` to refresh interval, which made it possible to share code verifier and auth state between tabs/windows (by having it in the`localStorage`).

## Issues related to this change

Closes #139.