### PR TITLE
chore: update packages in root- and example `package.json`, and remove eslint and react references

### DIFF
--- a/examples/microsoft-auth-provider/web-app/package.json
+++ b/examples/microsoft-auth-provider/web-app/package.json
@@ -1,19 +1,19 @@
 {
   "name": "ms-example-app",
   "version": "0.1.0",
-  "dependencies": {
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "react-oauth2-code-pkce": ">=1.8.4",
-    "react-scripts": "^5.0.1"
-  },
   "scripts": {
     "start": "ESLINT_NO_DEV_ERRORS='true' react-scripts start",
     "build": "react-scripts build"
   },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-oauth2-code-pkce": "1.17.1",
+    "react-scripts": "^5.0.1"
+  },
   "devDependencies": {
-    "@types/react": "^18.0.9",
-    "typescript": "^4.4.3"
+    "@types/react": "^18.2.58",
+    "typescript": "^5.3.3"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -1,32 +1,28 @@
 {
   "name": "package-development",
   "version": "0.1.0",
-  "dependencies": {
-    "react": ">=18.2.0",
-    "react-dom": ">=18.2.0",
-    "react-scripts": ">=5.0.1"
-  },
   "scripts": {
     "start": "ESLINT_NO_DEV_ERRORS='true' react-scripts start",
     "build": "react-scripts build",
     "test": "jest --silent",
     "test:watch": "jest --silent --watch"
   },
+  "dependencies": {
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0",
+    "react-scripts": ">=5.0.1"
+  },
   "devDependencies": {
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.4.3",
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/dom": "^9.2.0",
-    "@types/jest": "^29.5.1",
-    "@types/react": ">=17.0.21",
-    "eslint": ">=8.22.0",
-    "eslint-config-prettier": ">=8.5.0",
-    "eslint-plugin-prettier": ">=4.2.1",
-    "jest": "^29.5.0",
-    "jest-environment-jsdom": "^29.5.0",
-    "prettier": ">=2.7.1",
-    "ts-jest": "^29.1.0",
-    "typescript": ">=4.6.4"
+    "@testing-library/dom": "^9.3.4",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
+    "@types/react": "18.2.58",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "5.3.3"
   },
   "browserslist": {
     "production": [

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -191,7 +191,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   useEffect(() => {
     // The randomStagger is used to avoid multiple tabs logging in at the exact same time.
     const randomStagger = 10000 * Math.random()
-    const interval = setInterval(() => refreshAccessToken(), 5000 + randomStagger) // eslint-disable-line
+    const interval = setInterval(() => refreshAccessToken(), 5000 + randomStagger)
     return () => clearInterval(interval)
   }, [token, refreshToken, refreshTokenExpire, tokenExpire]) // Replace the interval with a new when values used inside refreshAccessToken changes
 
@@ -263,7 +263,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
       console.warn(`Failed to decode access token: ${(e as Error).message}`)
     }
     refreshAccessToken(true) // Check if token should be updated
-  }, []) // eslint-disable-line
+  }, [])
 
   return (
     <AuthContext.Provider


### PR DESCRIPTION
Update packages in root- and example `package.json`, and remove eslint and react references. We now use biome for linting and formatting.

## Issues related to this change
None.