### PR TITLE
feat: pass additional parameters to the login function

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ interface IAuthContext {
   tokenData?: TTokenData
   // Function to trigger login. 
   // If you want to use 'state', you might want to set 'clearURL' configuration parameter to 'false'.
-  login: (state?: string) => void  
+  login: (state?: string, additionalParameters?: { [key: string]: string | boolean | number }) => void  
   // Function to trigger logout from authentication provider. You may provide optional 'state', and 'logout_hint' values.
   // See https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout for details.
   logOut: (state?: string, logoutHint?: string) => void

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -4,6 +4,7 @@ import {
   IAuthContext,
   IAuthProvider,
   TInternalConfig,
+  TPrimitiveRecord,
   TRefreshTokenExpiredEvent,
   TTokenData,
   TTokenResponse,
@@ -77,7 +78,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     if (config?.logoutEndpoint && token) redirectToLogout(config, token, refreshToken, idToken, state, logoutHint)
   }
 
-  function login(state?: string, additionalParameters?: { [key: string]: string | boolean | number }) {
+  function login(state?: string, additionalParameters?: TPrimitiveRecord) {
     clearStorage()
     setLoginInProgress(true)
     // TODO: Raise error on wrong state type in v2

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -77,7 +77,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     if (config?.logoutEndpoint && token) redirectToLogout(config, token, refreshToken, idToken, state, logoutHint)
   }
 
-  function login(state?: string) {
+  function login(state?: string, additionalParameters?: { [key: string]: string | boolean | number }) {
     clearStorage()
     setLoginInProgress(true)
     // TODO: Raise error on wrong state type in v2
@@ -86,7 +86,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
       console.warn(`Passed login state must be of type 'string'. Received '${state}'. Ignoring value...`)
       typeSafePassedState = undefined
     }
-    redirectToLogin(config, typeSafePassedState).catch((error) => {
+    redirectToLogin(config, typeSafePassedState, additionalParameters).catch((error) => {
       console.error(error)
       setError(error.message)
       setLoginInProgress(false)

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -42,13 +42,15 @@ export interface IAuthProvider {
 export interface IAuthContext {
   token: string
   logOut: (state?: string, logoutHint?: string) => void
-  login: (state?: string, additionalParameters?: { [key: string]: string | boolean | number }) => void
+  login: (state?: string, additionalParameters?: TPrimitiveRecord) => void
   error: string | null
   tokenData?: TTokenData
   idToken?: string
   idTokenData?: TTokenData
   loginInProgress: boolean
 }
+
+export type TPrimitiveRecord = { [key: string]: string | boolean | number }
 
 // Input from users of the package, some optional values
 export type TAuthConfig = {
@@ -67,10 +69,10 @@ export type TAuthConfig = {
   autoLogin?: boolean
   clearURL?: boolean
   // TODO: Remove in 2.0
-  extraAuthParams?: { [key: string]: string | boolean | number }
-  extraAuthParameters?: { [key: string]: string | boolean | number }
-  extraTokenParameters?: { [key: string]: string | boolean | number }
-  extraLogoutParameters?: { [key: string]: string | boolean | number }
+  extraAuthParams?: TPrimitiveRecord
+  extraAuthParameters?: TPrimitiveRecord
+  extraTokenParameters?: TPrimitiveRecord
+  extraLogoutParameters?: TPrimitiveRecord
   tokenExpiresIn?: number
   refreshTokenExpiresIn?: number
   storage?: 'session' | 'local'
@@ -99,10 +101,10 @@ export type TInternalConfig = {
   autoLogin: boolean
   clearURL: boolean
   // TODO: Remove in 2.0
-  extraAuthParams?: { [key: string]: string | boolean | number }
-  extraAuthParameters?: { [key: string]: string | boolean | number }
-  extraTokenParameters?: { [key: string]: string | boolean | number }
-  extraLogoutParameters?: { [key: string]: string | boolean | number }
+  extraAuthParams?: TPrimitiveRecord
+  extraAuthParameters?: TPrimitiveRecord
+  extraTokenParameters?: TPrimitiveRecord
+  extraLogoutParameters?: TPrimitiveRecord
   tokenExpiresIn?: number
   refreshTokenExpiresIn?: number
   storage: 'session' | 'local'

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -42,7 +42,7 @@ export interface IAuthProvider {
 export interface IAuthContext {
   token: string
   logOut: (state?: string, logoutHint?: string) => void
-  login: (state?: string) => void
+  login: (state?: string, additionalParameters?: { [key: string]: string | boolean | number }) => void
   error: string | null
   tokenData?: TTokenData
   idToken?: string

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,5 +1,6 @@
 import {
   TInternalConfig,
+  TPrimitiveRecord,
   TTokenRequest,
   TTokenRequestForRefresh,
   TTokenRequestWithCodeAndVerifier,
@@ -14,7 +15,7 @@ const stateStorageKey = 'ROCP_auth_state'
 export async function redirectToLogin(
   config: TInternalConfig,
   customState?: string,
-  additionalParameters?: { [key: string]: string | boolean | number }
+  additionalParameters?: TPrimitiveRecord
 ): Promise<void> {
   const storage = config.storage === 'session' ? sessionStorage : localStorage
 

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -11,7 +11,11 @@ import { generateCodeChallenge, generateRandomString } from './pkceUtils'
 const codeVerifierStorageKey = 'PKCE_code_verifier'
 const stateStorageKey = 'ROCP_auth_state'
 
-export async function redirectToLogin(config: TInternalConfig, customState?: string): Promise<void> {
+export async function redirectToLogin(
+  config: TInternalConfig,
+  customState?: string,
+  additionalParameters?: { [key: string]: string | boolean | number }
+): Promise<void> {
   const storage = config.storage === 'session' ? sessionStorage : localStorage
 
   // Create and store a random string in storage, used as the 'code_verifier'
@@ -28,9 +32,10 @@ export async function redirectToLogin(config: TInternalConfig, customState?: str
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       ...config.extraAuthParameters,
+      ...additionalParameters,
     })
 
-    if (config.scope !== undefined) {
+    if (config.scope !== undefined && !params.has('scope')) {
       params.append('scope', config.scope)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,13 @@ function LoginInfo() {
   return (
     <>
       {error && <div style={{ color: 'red' }}>An error occurred during authentication: {error}</div>}
+      <>
+        <button onClick={login}>Login</button>
+        <button onClick={() => login('customLoginState')}>Login w/state</button>
+        <button onClick={() => login('customLoginState', { scope: 'profile', something: 123 })}>
+          Login w/extra params
+        </button>
+      </>
       {token ? (
         <>
           <button onClick={() => logOut('rememberThis', idTokenData.session_state)}>Logout</button>
@@ -93,11 +100,7 @@ function LoginInfo() {
           </div>
         </>
       ) : (
-        <>
-          <div style={{ backgroundColor: 'red' }}>You are not logged in</div>
-          <button onClick={login}>Login</button>
-          <button onClick={() => login('customLoginState')}>Login w/state</button>
-        </>
+        <div style={{ backgroundColor: 'red' }}>You are not logged in</div>
       )}
     </>
   )


### PR DESCRIPTION
## What does this pull request change?

- Add an optional parameter to `login()` that allows sending auth parameters others than those defined in the static config object.

## Issues related to this change
fixes #145 