### PR TITLE
fix: keep hash when clearing url after IDP bounce

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -240,7 +240,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
           .finally(() => {
             if (config.clearURL) {
               // Clear ugly url params
-              window.history.replaceState(null, '', window.location.pathname)
+              window.history.replaceState(null, '', `${window.location.pathname}${window.location.hash}`)
             }
             setLoginInProgress(false)
           })


### PR DESCRIPTION
## What does this pull request change?
- Make sure to keep hash when clearing URL

## Why is this pull request needed?
Any URL hash would be removed if `config.clearURL` was true

## Issues related to this change
could fix #143 
