### PR TITLE
refactor: add `@deprecated` notices to deprecated types and update notices of future changes

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -85,7 +85,10 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     // TODO: Raise error on wrong state type in v2
     let typeSafePassedState = state
     if (state && typeof state !== 'string') {
-      console.warn(`Passed login state must be of type 'string'. Received '${state}'. Ignoring value...`)
+      const jsonState = JSON.stringify(state)
+      console.warn(
+        `Passed login state must be of type 'string'. Received '${jsonState}'. Ignoring value. In a future version, an error will be thrown here.`
+      )
       typeSafePassedState = undefined
     }
     redirectToLogin(config, typeSafePassedState, additionalParameters).catch((error) => {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -19,7 +19,7 @@ export interface TTokenRequestForRefresh extends TTokenRqBase {
 export type TTokenRequest = TTokenRequestWithCodeAndVerifier | TTokenRequestForRefresh
 
 export type TTokenData = {
-  // biome-ignore lint: It really can be any, almost
+  // biome-ignore lint: It really can be `any` (almost)
   [x: string]: any
 }
 
@@ -70,7 +70,7 @@ export type TAuthConfig = {
   decodeToken?: boolean
   autoLogin?: boolean
   clearURL?: boolean
-  // TODO: Remove in 2.0
+  /** @deprecated Use `extraAuthParameters` instead. Will be removed in a future version. */
   extraAuthParams?: TPrimitiveRecord
   extraAuthParameters?: TPrimitiveRecord
   extraTokenParameters?: TPrimitiveRecord
@@ -84,7 +84,7 @@ export type TAuthConfig = {
 
 export type TRefreshTokenExpiredEvent = {
   logIn: () => void
-  /** @deprecated Use `logIn` instead */
+  /** @deprecated Use `logIn` instead. Will be removed in a future version. */
   login: () => void
 }
 
@@ -104,7 +104,7 @@ export type TInternalConfig = {
   decodeToken: boolean
   autoLogin: boolean
   clearURL: boolean
-  // TODO: Remove in 2.0
+  /** @deprecated Use `extraAuthParameters` instead. Will be removed in a future version. */
   extraAuthParams?: TPrimitiveRecord
   extraAuthParameters?: TPrimitiveRecord
   extraTokenParameters?: TPrimitiveRecord


### PR DESCRIPTION
This pull request includes refactoring changes to add `@deprecated` notices to deprecated types and update notices of future changes. The changes ensure that developers are aware of deprecated types and upcoming changes.