### PR TITLE
fix: no default refresh expire time

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,8 @@
         "useButtonType": "off"
       },
       "correctness": {
-        "useExhaustiveDependencies": "off"
+        "useExhaustiveDependencies": "off",
+        "noVoidTypeReturn": "off"
       }
     }
   }


### PR DESCRIPTION
## What does this pull request change?
- When a access_token expires, and there are no refreshToken, trigger "sessionExpired"-event

## Why is this pull request needed?
In cases where there were no refreshToken, the access token would expire without triggering a "session expired"-event

## Issues related to this change
closes #161 