### PR TITLE
fix: only set/overwrite id_token if a value is returned by auth provider

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -107,7 +107,9 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
 
   function handleTokenResponse(response: TTokenResponse) {
     setToken(response.access_token)
-    setIdToken(response.id_token)
+    if (response.id_token) {
+      setIdToken(response.id_token)
+    }
     let tokenExp = FALLBACK_EXPIRE_TIME
     // Decode IdToken, so we can use "exp" from that as fallback if expire not returned in the response
     try {


### PR DESCRIPTION
## Why is this pull request needed and what does it change?
As pointed out in #179, we currently overwrite the internal state for `idToken` every time we get a token response, but `response.id_token` is optional here, in the sense that it might only be sent for the first token, and then the auth provider can just assume the client keeps track of it. 

So we can't overwrite it with `undefined` when we don't get it at a later time. This PR makes it so.

## Issues related to this change
Closes #179.