### PR TITLE
fix: fetch tokens when loginInProgress is false

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -271,8 +271,10 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
         doFetchTokens(urlParams)
       }
       return
-    } else if (urlParams.get('code') && !didFetchTokens.current) {
+    }
+    if (urlParams.get('code') && !didFetchTokens.current) {
       doFetchTokens(urlParams)
+      return
     }
 
     // First page visit


### PR DESCRIPTION
Looks like a multi tab scenario is not fully supported. Please check the scenario:

1. Call `logIn()` on your web page. Here: 
- `loginInProgress` is set to `true`;
- you are navigated away to your auth endpoint, don't log in.
2. Meanwhile, open another instance of your web page in a new tab. Here:
- `loginInProgress` is true but urlParams doesn't have `code`, so a "Bad authorization state" error is set and `clearStorage()` is called, `loginInProgress` is set to `false`;
3. Finish login at your first tab. You are redirected back to your page with an auth code, but `loginInProgress` is already false. Nothing happens, and code is not replaced from the URL. If `autoLogin` is true, you are redirected to the auth endpoint again.

**_My suggestion is to perform token fetch_** even if `loginInProgress` is false but is there is a code in URL.
Maybe we need more conditions?
I don't think this behavior is fixable outside of the package.