### PR TITLE
fix: decode token(s) before rendering provider

### DIFF
--- a/src/decodeJWT.ts
+++ b/src/decodeJWT.ts
@@ -22,3 +22,21 @@ export const decodeJWT = (token: string): TTokenData => {
     )
   }
 }
+
+export const decodeAccessToken = (token: string | null | undefined): TTokenData | undefined => {
+  if (!token || !token.length) return undefined
+  try {
+    return decodeJWT(token)
+  } catch (e) {
+    console.warn(`Failed to decode access token: ${(e as Error).message}`)
+  }
+}
+
+export const decodeIdToken = (idToken: string | null | undefined): TTokenData | undefined => {
+  if (!idToken || !idToken.length) return undefined
+  try {
+    return decodeJWT(idToken)
+  } catch (e) {
+    console.warn(`Failed to decode idToken: ${(e as Error).message}`)
+  }
+}


### PR DESCRIPTION
## What does this pull request change?
- Decode tokens in a "useMemo" instead of a "useEffect"

## Why is this pull request needed?
- This remove one render cycle, where "loginInProgress" is false, "token" is set, but "tokenData" is undefined

## Issues related to this change
none