### PR TITLE
Remove obsolete postLogout() callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,6 @@ const authConfig = {
   onRefreshTokenExpire: (event) => event.logIn('', {}, 'popup'),
   preLogin: () => console.log('Logging in...'),
   postLogin: () => console.log('Logged in!'),
-  postLogout: () => console.log('Logged out!'),
   decodeToken: true,
   scope: 'profile openid',
   // state: 'testState',


### PR DESCRIPTION
## What does this pull request change?

This PR removes the `postLogout` callback given in `./src/index.js`. Its presence made me thinking this callback was actually supported and was just undocumented, cf. #187. But turns out, it seems to be just some leftover from the discussions of the issues stated below.

## Why is this pull request needed?

This clarifies that this library actually does not provide  callback that is called after logout.

## Issues related to this change

Discussions that might have introduced this as an artefact:
- https://github.com/soofstad/react-oauth2-pkce/issues/156
- https://github.com/soofstad/react-oauth2-pkce/issues/157
- https://github.com/soofstad/react-oauth2-pkce/issues/158