### PR TITLE
fix: autoLogin false not respected on expired refresh

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -132,8 +132,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
   }
 
   function handleExpiredRefreshToken(initial = false): void {
-    // If it's the first page load, OR there is no sessionExpire callback, we trigger a new login
-    if (initial) return logIn(undefined, undefined, config.loginMethod)
+    if (config.autoLogin && initial) return logIn(undefined, undefined, config.loginMethod)
 
     // TODO: Breaking change - remove automatic login during ongoing session
     if (!config.onRefreshTokenExpire) return logIn(undefined, undefined, config.loginMethod)


### PR DESCRIPTION
## What does this pull request change?
- Refactor `handleExpiredRefreshToken`.
- Changed logic on when to redirect to Login

## Why is this pull request needed?
- Fixes a bug that lead to `autoLogin=false` to not be respected on expired refresh token

## Issues related to this change
closes #202 