### PR TITLE
feat: option to use OAuth discovery endpoint for config

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -76,6 +76,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     setRefreshTokenExpire(undefined)
     setIdToken(undefined)
     setLoginInProgress(false)
+    localStorage.removeItem(`${config.storageKeyPrefix}well_known`)
   }
 
   function logOut(state?: string, logoutHint?: string, additionalParameters?: TPrimitiveRecord) {

--- a/src/authConfig.ts
+++ b/src/authConfig.ts
@@ -46,11 +46,11 @@ export function createInternalConfig(passedConfig: TAuthConfig): TInternalConfig
 export function validateConfig(config: TInternalConfig) {
   if (stringIsUnset(config?.clientId))
     throw Error("'clientId' must be set in the 'AuthConfig' object passed to 'react-oauth2-code-pkce' AuthProvider")
-  if (stringIsUnset(config?.authorizationEndpoint))
+  if (stringIsUnset(config?.authorizationEndpoint) && stringIsUnset(config?.discoveryEndpoint))
     throw Error(
       "'authorizationEndpoint' must be set in the 'AuthConfig' object passed to 'react-oauth2-code-pkce' AuthProvider"
     )
-  if (stringIsUnset(config?.tokenEndpoint))
+  if (stringIsUnset(config?.tokenEndpoint) && stringIsUnset(config?.discoveryEndpoint))
     throw Error(
       "'tokenEndpoint' must be set in the 'AuthConfig' object passed to 'react-oauth2-code-pkce' AuthProvider"
     )

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,9 +14,10 @@ import { AuthContext, AuthProvider } from './AuthContext'
 /** @type {import('./types').TAuthConfig} */
 const authConfig = {
   clientId: 'account',
-  authorizationEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/auth',
-  tokenEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/token',
-  logoutEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/logout',
+  discoveryEndpoint: 'https://keycloak.ofstad.xyz/realms/master/.well-known/openid-configuration',
+  // authorizationEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/auth',
+  // tokenEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/token',
+  // logoutEndpoint: 'https://keycloak.ofstad.xyz/realms/master/protocol/openid-connect/logout',
   redirectUri: 'http://localhost:5173/',
   onRefreshTokenExpire: (event) => event.logIn('', {}, 'popup'),
   preLogin: () => console.log('Logging in...'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,14 @@ export type TTokenData = {
   [x: string]: any
 }
 
+export type TWellKnown = {
+  authorization_endpoint: string
+  token_endpoint: string
+  revocation_endpoint: string
+  // biome-ignore lint: It really can be `any` (almost)
+  [x: string]: any
+}
+
 export type TTokenResponse = {
   access_token: string
   scope: string
@@ -61,11 +69,11 @@ export interface IAuthContext {
 
 export type TPrimitiveRecord = { [key: string]: string | boolean | number }
 
-// Input from users of the package, some optional values
-export type TAuthConfig = {
+type TAuthConfigBase = {
   clientId: string
-  authorizationEndpoint: string
-  tokenEndpoint: string
+  authorizationEndpoint?: string
+  tokenEndpoint?: string
+  discoveryEndpoint?: string
   redirectUri: string
   scope?: string
   state?: string
@@ -92,17 +100,29 @@ export type TAuthConfig = {
   tokenRequestCredentials?: RequestCredentials
 }
 
+// Input from users of the package, some optional values
+export type TAuthConfig = TAuthConfigBase &
+  (
+    | {
+        authorizationEndpoint: string
+        tokenEndpoint: string
+        discoveryEndpoint?: string
+      }
+    | {
+        discoveryEndpoint: string
+        tokenEndpoint?: string
+        authorizationEndpoint?: string
+      }
+  )
+
 export type TRefreshTokenExpiredEvent = {
   logIn: (state?: string, additionalParameters?: TPrimitiveRecord, method?: 'redirect' | 'popup') => void
   /** @deprecated Use `logIn` instead. Will be removed in a future version. */
   login: (state?: string, additionalParameters?: TPrimitiveRecord, method?: 'redirect' | 'popup') => void
 }
 
-// The AuthProviders internal config type. All values will be set by user provided, or default values
-export type TInternalConfig = {
+type TInternalConfigBase = {
   clientId: string
-  authorizationEndpoint: string
-  tokenEndpoint: string
   redirectUri: string
   scope?: string
   state?: string
@@ -128,3 +148,17 @@ export type TInternalConfig = {
   refreshWithScope: boolean
   tokenRequestCredentials: RequestCredentials
 }
+// The AuthProviders internal config type. All values will be set by user provided, or default values
+export type TInternalConfig = TInternalConfigBase &
+  (
+    | {
+        authorizationEndpoint: string
+        tokenEndpoint: string
+        discoveryEndpoint?: string
+      }
+    | {
+        discoveryEndpoint: string
+        tokenEndpoint?: string
+        authorizationEndpoint?: string
+      }
+  )


### PR DESCRIPTION
## What does this pull request change?
- Option to use oauth .well-known endpoint for grabbing config

## Why is this pull request needed?

## Issues related to this change
closes #199 

## Missing

- [ ] Docs
- [ ] Option to disable "true logout"?
- [ ] Stronger validation?
- [ ] Any problems with multiple tabs?
