### PR TITLE
feat: Replace config.state with callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ type TAuthConfig = {
   redirectUri: string  // Required
   // Which scopes to request for the auth token
   scope?: string  // default: ''
+  // Optional state value. Will often make more sense to provide the state in a call to the 'logIn()' function
+  state?: string // default: null
   // Optional state function. This function should generate a random, URL-safe String. 
   stateFn?: () => string // default: undefined
   // Which URL to call for logging out of the auth provider

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ type TAuthConfig = {
   redirectUri: string  // Required
   // Which scopes to request for the auth token
   scope?: string  // default: ''
-  // Optional state value. Will often make more sense to provide the state in a call to the 'logIn()' function
+  // Optional state value. Will often make more sense to provide the state in a call to the 'logIn()' function. This takes precedence over the below 'stateFn'. 
   state?: string // default: null
   // Optional state function. This function should generate a random, URL-safe String. 
   stateFn?: () => string // default: undefined

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ type TAuthConfig = {
   redirectUri: string  // Required
   // Which scopes to request for the auth token
   scope?: string  // default: ''
-  // Optional state value. Will often make more sense to provide the state in a call to the 'logIn()' function
-  state?: string // default: null
+  // Optional state function. This function should generate a random, URL-safe String. 
+  stateFn?: () => string // default: undefined
   // Which URL to call for logging out of the auth provider
   logoutEndpoint?: string  // default: null
   // Which URL the auth provider should redirect the user to after logout

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -43,7 +43,7 @@ export async function redirectToLogin(
     }
 
     storage.removeItem(stateStorageKey)
-    const state = customState ?? (config.stateFn && config.stateFn())
+    const state = customState ?? config.state ?? (config.stateFn && config.stateFn())
     if (state) {
       storage.setItem(stateStorageKey, state)
       params.append('state', state)

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -43,7 +43,7 @@ export async function redirectToLogin(
     }
 
     storage.removeItem(stateStorageKey)
-    const state = customState ?? config.state
+    const state = customState ?? (config.stateFn && config.stateFn())
     if (state) {
       storage.setItem(stateStorageKey, state)
       params.append('state', state)

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export type TAuthConfig = {
   tokenEndpoint: string
   redirectUri: string
   scope?: string
-  state?: string
+  stateFn?: () => string
   logoutEndpoint?: string
   logoutRedirect?: string
   preLogin?: () => void
@@ -105,7 +105,7 @@ export type TInternalConfig = {
   tokenEndpoint: string
   redirectUri: string
   scope?: string
-  state?: string
+  stateFn?: () => string
   logoutEndpoint?: string
   logoutRedirect?: string
   preLogin?: () => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export type TAuthConfig = {
   tokenEndpoint: string
   redirectUri: string
   scope?: string
+  state?: string
   stateFn?: () => string
   logoutEndpoint?: string
   logoutRedirect?: string
@@ -105,6 +106,7 @@ export type TInternalConfig = {
   tokenEndpoint: string
   redirectUri: string
   scope?: string
+  state?: string
   stateFn?: () => string
   logoutEndpoint?: string
   logoutRedirect?: string

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -11,7 +11,7 @@ export const authConfig: TAuthConfig = {
   logoutRedirect: 'primary-logout-redirect',
   scope: 'someScope openid',
   decodeToken: false,
-  state: 'testState',
+  stateFn: () => 'testState',
   loginMethod: 'redirect',
   extraLogoutParameters: {
     testLogoutKey: 'logoutValue',


### PR DESCRIPTION
## What does this pull request change?
This PR adds `TAuthConfig.stateFn`, a callback for generating a random state String. The appropriate documentation is also updated.

## Why is this pull request needed?
This allows for applications to generate and use states without having to manually generate a state every time `IAuthContext.logIn` is called. This also enables states to be used in the initial log in when `TAuthConfig.autoLogin` is true.

## Issues related to this change
None