### PR TITLE
feat: add replace history option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ type TAuthConfig = {
   // Warning: Including browser credentials deviates from the standard protocol and can introduce unforeseen security issues. Only set this to 'include' if you know what 
   // you are doing and CSRF protection is present. Setting this to 'include' is required when the token endpoint requires client certificate authentication, but likely is
   // not needed in any other case. Use with caution.
-  tokenRequestCredentials?: 'same-origin'|'include'|'omit' // default: 'same-origin'
+  tokenRequestCredentials?: 'same-origin' | 'include' | 'omit' // default: 'same-origin'
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ interface IAuthContext {
   // Function to trigger login. 
   // If you want to use 'state', you might want to set 'clearURL' configuration parameter to 'false'.
   // Note that most browsers block popups by default. The library will print a warning and fallback to redirect if the popup is blocked
-  logIn: (state?: string, additionalParameters?: { [key: string]: string | boolean | number }, method: 'redirect' | 'popup' = 'redirect') => void
+  logIn: (state?: string, additionalParameters?: { [key: string]: string | boolean | number }, method: TLoginMethod = 'redirect') => void
   // Function to trigger logout from authentication provider. You may provide optional 'state', and 'logout_hint' values.
   // See https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout for details.
   logOut: (state?: string, logoutHint?: string, additionalParameters?: { [key: string]: string | boolean | number }) => void
@@ -135,9 +135,9 @@ type TAuthConfig = {
   // Optionally provide a callback function to run _after_ the
   // user has been redirected back from the auth server
   postLogin?: () => void  // default: () => null
-  // Which method to use for login. Can be either 'redirect' or 'popup'
+  // Which method to use for login. Can be 'redirect', 'replace', or 'popup'
   // Note that most browsers block popups by default. The library will print a warning and fallback to redirect if the popup is blocked
-  loginMethod: 'redirect' | 'popup'  // default: 'redirect'
+  loginMethod: 'redirect' | 'replace' | 'popup'  // default: 'redirect'
   // Optional callback function for the 'refreshTokenExpired' event.
   // You likely want to display a message saying the user need to log in again. A page refresh is enough.
   onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void  // default: undefined

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -9,6 +9,7 @@ import type {
   IAuthContext,
   IAuthProvider,
   TInternalConfig,
+  TLoginMethod,
   TPrimitiveRecord,
   TRefreshTokenExpiredEvent,
   TTokenData,
@@ -58,7 +59,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
     false,
     config.storage
   )
-  const [loginMethod, setLoginMethod] = useBrowserStorage<'redirect' | 'popup'>(
+  const [loginMethod, setLoginMethod] = useBrowserStorage<TLoginMethod>(
     `${config.storageKeyPrefix}loginMethod`,
     'redirect',
     config.storage
@@ -85,7 +86,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
       redirectToLogout(config, token, refreshToken, idToken, state, logoutHint, additionalParameters)
   }
 
-  function logIn(state?: string, additionalParameters?: TPrimitiveRecord, method: 'redirect' | 'popup' = 'redirect') {
+  function logIn(state?: string, additionalParameters?: TPrimitiveRecord, method: TLoginMethod = 'redirect') {
     clearStorage()
     setLoginInProgress(true)
     setLoginMethod(method)

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -3,6 +3,7 @@ import { generateCodeChallenge, generateRandomString } from './pkceUtils'
 import { calculatePopupPosition } from './popupUtils'
 import type {
   TInternalConfig,
+  TLoginMethod,
   TPrimitiveRecord,
   TTokenRequest,
   TTokenRequestForRefresh,
@@ -17,7 +18,7 @@ export async function redirectToLogin(
   config: TInternalConfig,
   customState?: string,
   additionalParameters?: TPrimitiveRecord,
-  method: 'popup' | 'redirect' = 'redirect'
+  method: TLoginMethod = 'redirect'
 ): Promise<void> {
   const storage = config.storage === 'session' ? sessionStorage : localStorage
 

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -21,6 +21,7 @@ export async function redirectToLogin(
   method: TLoginMethod = 'redirect'
 ): Promise<void> {
   const storage = config.storage === 'session' ? sessionStorage : localStorage
+  const navigationMethod = method === 'replace' ? 'replace' : 'assign'
 
   // Create and store a random string in storage, used as the 'code_verifier'
   const codeVerifier = generateRandomString(96)
@@ -65,7 +66,7 @@ export async function redirectToLogin(
       if (handle) return
       console.warn('Popup blocked. Redirecting to login page. Disable popup blocker to use popup login.')
     }
-    window.location.assign(loginUrl)
+    window.location[navigationMethod](loginUrl)
   })
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 import type { ReactNode } from 'react'
 
+// Makes only the specified keys required in the provided type
+// Source: https://www.emmanuelgautier.com/blog/snippets/typescript-required-properties
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
+
 interface TTokenRqBase {
   grant_type: string
   client_id: string
@@ -34,6 +38,8 @@ export type TTokenResponse = {
   id_token?: string
 }
 
+export type TLoginMethod = 'redirect' | 'popup'
+
 export type TPopupPosition = {
   left: number
   top: number
@@ -46,12 +52,13 @@ export interface IAuthProvider {
   children: ReactNode
 }
 
+type TLogInFunction = (state?: string, additionalParameters?: TPrimitiveRecord, method?: TLoginMethod) => void
 export interface IAuthContext {
   token: string
-  logIn: (state?: string, additionalParameters?: TPrimitiveRecord, method?: 'redirect' | 'popup') => void
+  logIn: TLogInFunction
   logOut: (state?: string, logoutHint?: string, additionalParameters?: TPrimitiveRecord) => void
   /** @deprecated Use `logIn` instead */
-  login: (state?: string, additionalParameters?: TPrimitiveRecord) => void
+  login: TLogInFunction
   error: string | null
   tokenData?: TTokenData
   idToken?: string
@@ -73,7 +80,7 @@ export type TAuthConfig = {
   logoutRedirect?: string
   preLogin?: () => void
   postLogin?: () => void
-  loginMethod?: 'redirect' | 'popup'
+  loginMethod?: TLoginMethod
   onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void
   decodeToken?: boolean
   autoLogin?: boolean
@@ -93,38 +100,21 @@ export type TAuthConfig = {
 }
 
 export type TRefreshTokenExpiredEvent = {
-  logIn: (state?: string, additionalParameters?: TPrimitiveRecord, method?: 'redirect' | 'popup') => void
+  logIn: TLogInFunction
   /** @deprecated Use `logIn` instead. Will be removed in a future version. */
-  login: (state?: string, additionalParameters?: TPrimitiveRecord, method?: 'redirect' | 'popup') => void
+  login: TLogInFunction
 }
 
 // The AuthProviders internal config type. All values will be set by user provided, or default values
-export type TInternalConfig = {
-  clientId: string
-  authorizationEndpoint: string
-  tokenEndpoint: string
-  redirectUri: string
-  scope?: string
-  state?: string
-  logoutEndpoint?: string
-  logoutRedirect?: string
-  preLogin?: () => void
-  postLogin?: () => void
-  loginMethod: 'redirect' | 'popup'
-  onRefreshTokenExpire?: (event: TRefreshTokenExpiredEvent) => void
-  decodeToken: boolean
-  autoLogin: boolean
-  clearURL: boolean
-  /** @deprecated Use `extraAuthParameters` instead. Will be removed in a future version. */
-  extraAuthParams?: TPrimitiveRecord
-  extraAuthParameters?: TPrimitiveRecord
-  extraTokenParameters?: TPrimitiveRecord
-  extraLogoutParameters?: TPrimitiveRecord
-  tokenExpiresIn?: number
-  refreshTokenExpiresIn?: number
-  refreshTokenExpiryStrategy: 'renewable' | 'absolute'
-  storage: 'session' | 'local'
-  storageKeyPrefix: string
-  refreshWithScope: boolean
-  tokenRequestCredentials: RequestCredentials
-}
+export type TInternalConfig = WithRequired<
+  TAuthConfig,
+  | 'loginMethod'
+  | 'decodeToken'
+  | 'autoLogin'
+  | 'clearURL'
+  | 'refreshTokenExpiryStrategy'
+  | 'storage'
+  | 'storageKeyPrefix'
+  | 'refreshWithScope'
+  | 'tokenRequestCredentials'
+>

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type TTokenResponse = {
   id_token?: string
 }
 
-export type TLoginMethod = 'redirect' | 'popup'
+export type TLoginMethod = 'redirect' | 'replace' | 'popup'
 
 export type TPopupPosition = {
   left: number


### PR DESCRIPTION
## What does this pull request change?
It adds the ability to replace the browser history entry when redirecting to the authorization page, as well as refactors some type code and docs.

## Why is this pull request needed?
To give the ability to replace the browser history entry instead of creating a new one in some cases, and to keep the code base clean.

## Issues related to this change
#210 