### PR TITLE
feat: add logInSilent method to AuthContext

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,12 +53,14 @@ export interface IAuthProvider {
 }
 
 type TLogInFunction = (state?: string, additionalParameters?: TPrimitiveRecord, method?: TLoginMethod) => void
+type TLogInSilentFunction = (initial?: boolean) => void
 export interface IAuthContext {
   token: string
   logIn: TLogInFunction
   logOut: (state?: string, logoutHint?: string, additionalParameters?: TPrimitiveRecord) => void
   /** @deprecated Use `logIn` instead */
   login: TLogInFunction
+  logInSilent: TLogInSilentFunction
   error: string | null
   tokenData?: TTokenData
   idToken?: string


### PR DESCRIPTION
## What does this pull request change?
This PR changes just two files
- AuthContext.tsx
- types.ts

To add and expose a new function to authentication class.

## Why is this pull request needed?
This feature allow users to start by themselves the silent login procedure instead to use `autoLogin: true` in configuration

Porpuse: allow other auth mechanism shared with subdomains to update refresh token befere starting oauth login