### PR TITLE
Fix: Reset error state after successful token response

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -130,6 +130,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
         setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
       }
     }
+    setError(null);
   }
 
   function handleExpiredRefreshToken(initial = false): void {

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -130,7 +130,7 @@ export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {
         setRefreshTokenExpire(epochAtSecondsFromNow(refreshTokenExpiresIn))
       }
     }
-    setError(null);
+    setError(null)
   }
 
   function handleExpiredRefreshToken(initial = false): void {


### PR DESCRIPTION
## What does this pull request change?
Currently, the error state is not cleared after the successful token response. The error state gets set when there is an error while getting the token. However, the error state is not cleared even if the subsequent requests were successful.

## Why is this pull request needed?
If anyone uses the `error` property to display the error. The error will always be displayed since it is not cleared after the successful token request.

## Issues related to this change
closes #221