### PR TITLE
ci: add conventional commits check workflow

### DIFF
--- a/.github/workflows/conventional-commits-check.yaml
+++ b/.github/workflows/conventional-commits-check.yaml
@@ -1,0 +1,49 @@
+name: Conventional Commits Check
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
+
+jobs:
+  check-conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Commit Conventions
+        uses: webiny/action-conventional-commits@v1.3.0
+
+      - name: Check Semantic Pull Request title
+        uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fail, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce commit message and pull request title conventions based on the Conventional Commits specification. The workflow ensures consistency and semantic clarity in commit messages and pull request titles.

### Workflow addition:

* `.github/workflows/conventional-commits-check.yaml`: Added a new workflow named "Conventional Commits Check" that runs on pull request events (`opened`, `synchronize`, `reopened`, `edited`). It includes steps to:
  - Check out the repository (`actions/checkout@v4`).
  - Validate commit messages using `webiny/action-conventional-commits@v1.3.0`.
  - Lint pull request titles for semantic compliance using `amannn/action-semantic-pull-request@v5`.
  - Post a comment with error details if the pull request title does not comply, using `marocchino/sticky-pull-request-comment@v2`. The comment is deleted automatically once the issue is resolved.