### PR TITLE
feat: add storageKeyPrefix to codeVerifierStorageKey per issue 231

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -25,7 +25,9 @@ export async function redirectToLogin(
 
   // Create and store a random string in storage, used as the 'code_verifier'
   const codeVerifier = generateRandomString(96)
-  storage.setItem(codeVerifierStorageKey, codeVerifier)
+  // Prefix the code verifier key name to prevent multi-application collisions
+  const codeVerifierStorageKeyName = config.storageKeyPrefix + codeVerifierStorageKey
+  storage.setItem(codeVerifierStorageKeyName, codeVerifier)
 
   // Hash and Base64URL encode the code_verifier, used as the 'code_challenge'
   return generateCodeChallenge(codeVerifier).then((codeChallenge) => {
@@ -99,7 +101,9 @@ export const fetchTokens = (config: TInternalConfig): Promise<TTokenResponse> =>
   */
   const urlParams = new URLSearchParams(window.location.search)
   const authCode = urlParams.get('code')
-  const codeVerifier = storage.getItem(codeVerifierStorageKey)
+  // Prefix the code verifier key name to prevent multi-application collisions
+  const codeVerifierStorageKeyName = config.storageKeyPrefix + codeVerifierStorageKey
+  const codeVerifier = storage.getItem(codeVerifierStorageKeyName)
 
   if (!authCode) {
     throw Error("Parameter 'code' not found in URL. \nHas authentication taken place?")

--- a/src/pkceUtils.ts
+++ b/src/pkceUtils.ts
@@ -29,7 +29,7 @@ export async function generateCodeChallenge(codeVerifier: string): Promise<strin
   }
   const encoder = new TextEncoder()
   const bytes: Uint8Array = encoder.encode(codeVerifier) // Encode the verifier to a byteArray
-  const hash: ArrayBuffer = await window.crypto.subtle.digest('SHA-256', bytes) // sha256 hash it
+  const hash: ArrayBuffer = await window.crypto.subtle.digest('SHA-256', bytes as BufferSource); // sha256 hash it
   const hashString: string = String.fromCharCode(...new Uint8Array(hash))
   const base64 = btoa(hashString) // Base64 encode the verifier hash
   return base64 // Base64Url encode the base64 encoded string, making it safe as a query param

--- a/tests/get_token.test.tsx
+++ b/tests/get_token.test.tsx
@@ -23,7 +23,7 @@ describe('make token request', () => {
   beforeEach(() => {
     // Setting up a state similar to what it would be just after redirect back from auth provider
     localStorage.setItem('ROCP_loginInProgress', 'true')
-    localStorage.setItem('PKCE_code_verifier', 'arandomstring')
+    localStorage.setItem('ROCP_PKCE_code_verifier', 'arandomstring')
     window.location.search = '?code=1234'
   })
 

--- a/tests/jestSetup.js
+++ b/tests/jestSetup.js
@@ -5,7 +5,7 @@ beforeEach(() => {
   localStorage.removeItem('ROCP_loginInProgress')
   localStorage.removeItem('ROCP_token')
   localStorage.removeItem('ROCP_refreshToken')
-  localStorage.removeItem('PKCE_code_verifier')
+  localStorage.removeItem('ROCP_PKCE_code_verifier')
 
   global.TextEncoder = TextEncoder
   global.TextDecoder = TextDecoder


### PR DESCRIPTION
## What does this pull request change?
- Prepend storageKeyPrefix to codeVerifierStorageKey
- Update tests to prepend ROCP_ to PKCE_code_verifier

## Why is this pull request needed?
- Per issue #231 this will prevent collisions when multiple applications use the package on the same domain and are invoked at the same time

## Issues related to this change
closes #231