### PR TITLE
Added parameter for additional headers on get_token call

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -80,9 +80,10 @@ function isTokenResponse(body: unknown | TTokenResponse): body is TTokenResponse
 function postTokenRequest(
   tokenEndpoint: string,
   tokenRequest: TTokenRequest,
-  credentials: RequestCredentials
+  credentials: RequestCredentials,
+  headers?: TPrimitiveRecord
 ): Promise<TTokenResponse> {
-  return postWithXForm({ url: tokenEndpoint, request: tokenRequest, credentials: credentials }).then((response) => {
+  return postWithXForm({ url: tokenEndpoint, request: tokenRequest, credentials: credentials, headers }).then((response) => {
     return response.json().then((body: TTokenResponse | unknown): TTokenResponse => {
       if (isTokenResponse(body)) {
         return body
@@ -122,7 +123,7 @@ export const fetchTokens = (config: TInternalConfig): Promise<TTokenResponse> =>
     // TODO: Remove in 2.0
     ...config.extraAuthParams,
   }
-  return postTokenRequest(config.tokenEndpoint, tokenRequest, config.tokenRequestCredentials)
+  return postTokenRequest(config.tokenEndpoint, tokenRequest, config.tokenRequestCredentials, config.extraTokenHeaders)
 }
 
 export const fetchWithRefreshToken = (props: {

--- a/src/httpUtils.ts
+++ b/src/httpUtils.ts
@@ -1,31 +1,42 @@
-import { FetchError } from './errors'
-import type { TTokenRequest } from './types'
+import { FetchError } from "./errors";
+import type { TPrimitiveRecord, TTokenRequest } from "./types";
 
 function buildUrlEncodedRequest(request: TTokenRequest): string {
-  let queryString = ''
+  let queryString = "";
   for (const [key, value] of Object.entries(request)) {
-    queryString += `${queryString ? '&' : ''}${key}=${encodeURIComponent(value)}`
+    queryString += `${queryString ? "&" : ""}${key}=${encodeURIComponent(
+      value
+    )}`;
   }
-  return queryString
+  return queryString;
 }
 
 interface PostWithXFormParams {
-  url: string
-  request: TTokenRequest
-  credentials: RequestCredentials
+  url: string;
+  request: TTokenRequest;
+  credentials: RequestCredentials;
+  headers?: TPrimitiveRecord;
 }
 
-export async function postWithXForm({ url, request, credentials }: PostWithXFormParams): Promise<Response> {
+export async function postWithXForm({
+  url,
+  request,
+  credentials,
+  headers,
+}: PostWithXFormParams): Promise<Response> {
   return fetch(url, {
-    method: 'POST',
+    method: "POST",
     body: buildUrlEncodedRequest(request),
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...headers,
+    },
     credentials: credentials,
   }).then(async (response: Response) => {
     if (!response.ok) {
-      const responseBody = await response.text()
-      throw new FetchError(response.status, response.statusText, responseBody)
+      const responseBody = await response.text();
+      throw new FetchError(response.status, response.statusText, responseBody);
     }
-    return response
-  })
+    return response;
+  });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export type TAuthConfig = {
   /** @deprecated Use `extraAuthParameters` instead. Will be removed in a future version. */
   extraAuthParams?: TPrimitiveRecord
   extraAuthParameters?: TPrimitiveRecord
+  extraTokenHeaders?: TPrimitiveRecord
   extraTokenParameters?: TPrimitiveRecord
   extraLogoutParameters?: TPrimitiveRecord
   tokenExpiresIn?: number

--- a/tests/get_token.test.tsx
+++ b/tests/get_token.test.tsx
@@ -64,4 +64,24 @@ describe('make token request', () => {
       })
     )
   })
+
+  test('with extra headers', async () => {
+    render(
+      <AuthProvider authConfig={{ ...authConfig, extraTokenHeaders: { 'X-Test-Header': 'TestValue' } }}>
+        <AuthConsumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith('myTokenEndpoint', {
+        body: 'grant_type=authorization_code&code=1234&client_id=anotherClientId&redirect_uri=http%3A%2F%2Flocalhost%2F&code_verifier=arandomstring&testTokenKey=tokenValue',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-Test-Header': 'TestValue',
+        },
+        method: 'POST',
+        credentials: 'same-origin',
+      })
+    )
+  });
 })


### PR DESCRIPTION
## What does this pull request change?
- Added parameter for additional headers on get_token call

## Why is this pull request needed?
- because some OAuth clients requires additional headers, when requesting the token.
