### PR TITLE
feat: expose interactive refresh access token

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,13 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-node@v6
         with:
-          python-version: '3.11'
-      - name: Install pre-commit
-        run: pip install pre-commit
-      - name: Run pre-commit
-        run: pre-commit run --all-files
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install prek
+        run: npm install -g @j178/prek
+      - name: Install dependencies
+        run: npm install
+      - name: Run pre-commit (via prek)
+        run: prek run --all-files
 
   unittests:
     runs-on: ubuntu-latest
@@ -31,4 +34,3 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run test
-      - run: cd src && tsc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,12 @@ repos:
       - id: biome-check
         args: ["--unsafe"]
         additional_dependencies: ["@biomejs/biome@2.1.4"]
+
+  - repo: local
+    hooks:
+      - id: typescript-check
+        name: typescript-check
+        entry: npx --package=typescript tsc --noEmit
+        language: system
+        types_or: [ ts, tsx ]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ interface IAuthContext {
   idTokenData?: TTokenData
   // If the <AuthProvider> is done fetching tokens or not. Usefull for controlling page rendering
   loginInProgress: boolean
+  // The library handles silently refreshing access tokens automatically be default.
+  // This function is exposed if you for some reason need to trigger a refresh manually.
+  // You will need to handle any errors thrown. Usually by calling 'logIn()'.
+  refreshAccessToken: async () => Promise<void>
 }
 ```
 

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -26,6 +26,7 @@ export const AuthContext = createContext<IAuthContext>({
   logOut: () => null,
   error: null,
   loginInProgress: false,
+  refreshAccessToken: () => null,
 })
 
 export const AuthProvider = ({ authConfig, children }: IAuthProvider) => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -32,13 +32,18 @@ const authConfig = {
 }
 
 function LoginInfo() {
-  const { tokenData, token, idTokenData, logIn, logOut, error, loginInProgress } = useAuthContext()
+  const { tokenData, token, idTokenData, logIn, logOut, error, loginInProgress, refreshAccessToken } = useAuthContext()
 
   if (loginInProgress) return null
   return (
     <>
       {error && <div style={{ color: 'red' }}>An error occurred during authentication: {error}</div>}
 
+      <button
+        onClick={() => refreshAccessToken().catch((err) => alert(`Failed to refresh access token: ${err.message}`))}
+      >
+        Refresh access token
+      </button>
       <button onClick={() => logIn('', {}, 'popup')}>Log in w/popup</button>
       <button onClick={() => logIn()}>Log in w/redirect</button>
       <button onClick={() => logIn('customLoginState')}>Log in w/state</button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface IAuthContext {
   idToken?: string
   idTokenData?: TTokenData
   loginInProgress: boolean
+  refreshAccessToken: () => void
 }
 
 export type TPrimitiveRecord = { [key: string]: string | boolean | number }


### PR DESCRIPTION
## What does this pull request change?
- Expose a new function - "refreshAccessToken"
- Replace pre-commit runner in CI with `prek`

## Why is this pull request needed?
- In some rare cases, the option to manually refresh the access token might be needed. For example when the access token has been revoked, but not the refresh token.

