### PR TITLE
Make AuthProvider compatible with SSR frameworks such as React Router and NextJS

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,6 +1,7 @@
 import { postWithXForm } from './httpUtils'
 import { generateCodeChallenge, generateRandomString } from './pkceUtils'
 import { calculatePopupPosition } from './popupUtils'
+import { getStorageImplementation } from './storageUtils'
 import type {
   TInternalConfig,
   TLoginMethod,
@@ -20,7 +21,7 @@ export async function redirectToLogin(
   additionalParameters?: TPrimitiveRecord,
   method: TLoginMethod = 'redirect'
 ): Promise<void> {
-  const storage = config.storage === 'session' ? sessionStorage : localStorage
+  const storage = getStorageImplementation(config.storage)
   const navigationMethod = method === 'replace' ? 'replace' : 'assign'
 
   // Create and store a random string in storage, used as the 'code_verifier'
@@ -95,7 +96,7 @@ function postTokenRequest(
 }
 
 export const fetchTokens = (config: TInternalConfig): Promise<TTokenResponse> => {
-  const storage = config.storage === 'session' ? sessionStorage : localStorage
+  const storage = getStorageImplementation(config.storage)
   /*
     The browser has been redirected from the authentication endpoint with
     a 'code' url parameter.
@@ -170,7 +171,7 @@ export function redirectToLogout(
 }
 
 export function validateState(urlParams: URLSearchParams, storageType: TInternalConfig['storage']) {
-  const storage = storageType === 'session' ? sessionStorage : localStorage
+  const storage = getStorageImplementation(storageType)
   const receivedState = urlParams.get('state')
   const loadedState = storage.getItem(stateStorageKey)
   if (receivedState !== loadedState) {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-code-pkce",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Provider agnostic react package for OAuth2 Authorization Code flow with PKCE",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/storageUtils.ts
+++ b/src/storageUtils.ts
@@ -1,0 +1,30 @@
+// Storage implementation for SSR
+// This does nothing, but prevents errors due to localStorage / sessionStorage not being defined
+class SSRStorage implements Storage {
+  length: number
+
+  constructor() {
+    this.length = 0
+  }
+
+  clear() {}
+
+  getItem(key: string): string | null {
+    return null
+  }
+
+  key(index: number): string | null {
+    return null
+  }
+
+  removeItem(key: string): void {}
+
+  setItem(key: string, value: string): void {}
+}
+
+export function getStorageImplementation(type: 'session' | 'local'): Storage {
+  if (typeof window === 'undefined') {
+    return new SSRStorage()
+  }
+  return type === 'session' ? window.sessionStorage : window.localStorage
+}

--- a/src/storageUtils.ts
+++ b/src/storageUtils.ts
@@ -9,17 +9,17 @@ class SSRStorage implements Storage {
 
   clear() {}
 
-  getItem(key: string): string | null {
+  getItem(_key: string): string | null {
     return null
   }
 
-  key(index: number): string | null {
+  key(_index: number): string | null {
     return null
   }
 
-  removeItem(key: string): void {}
+  removeItem(_key: string): void {}
 
-  setItem(key: string, value: string): void {}
+  setItem(_key: string, _value: string): void {}
 }
 
 export function getStorageImplementation(type: 'session' | 'local'): Storage {

--- a/src/useBrowserStorage.ts
+++ b/src/useBrowserStorage.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { getStorageImplementation } from './storageUtils'
 
 export function useBrowserStorage<T>(key: string, initialValue: T, type: 'session' | 'local'): [T, (v: T) => void] {
-  const storage = getStorageImplementation(type);
+  const storage = getStorageImplementation(type)
 
   const [storedValue, setStoredValue] = useState<T>(() => {
     const item = storage.getItem(key)

--- a/src/useBrowserStorage.ts
+++ b/src/useBrowserStorage.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
+import { getStorageImplementation } from './storageUtils'
 
 export function useBrowserStorage<T>(key: string, initialValue: T, type: 'session' | 'local'): [T, (v: T) => void] {
-  const storage = type === 'session' ? sessionStorage : localStorage
+  const storage = getStorageImplementation(type);
 
   const [storedValue, setStoredValue] = useState<T>(() => {
     const item = storage.getItem(key)


### PR DESCRIPTION
## What does this pull request change?
Replaces usages of `sessionStorage` and `localStorage` with an SSR friendly implementation.  
During server side rendering a dummy Storage implementation is returned.

## Why is this pull request needed?
Makes AuthProvider compatible with SSR frameworks such as React Router and NextJS

## Issues related to this change
https://github.com/soofstad/react-oauth2-pkce/issues/91